### PR TITLE
Feat/promise api

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,9 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [Unreleased]
 ### Added
+- add promise-based functions to load the script and modules
 ### Changed
+- deprecate `bootstrap()` and `dojoRequire()`
 - add code coverage
 - add release script
 ### Fixed

--- a/README.md
+++ b/README.md
@@ -190,9 +190,21 @@ Here are some applications that use this library (presented by framework in alph
 
 ## Dependencies
 
-This library doesn't have any external dependencies, but it expects to be run in a browser (i.e. not Node.js). Since v1.5 asynchronous functions like `loadScript()` and `loadModules()` return [`Promise`s](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Promise), so if your application has to support [browers that don't support Promise (i.e. IE)](https://caniuse.com/#search=promise), then you should consider using a [Promise polyfill](https://www.google.com/search?q=promise+polyfill), ideally [only when needed](https://philipwalton.com/articles/loading-polyfills-only-when-needed/).
+This library doesn't have any external dependencies, but it expects to be run in a browser (i.e. not Node.js). Since v1.5 asynchronous functions like `loadScript()` and `loadModules()` return [`Promise`s](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Promise), so if your application has to support [browers that don't support Promise (i.e. IE)](https://caniuse.com/#search=promise) you have a few options.
 
-Alternatively, you can still use `bootstrap()` and `dojoRequire()` which are the callback-based equivalents of the above functions. See the [v1.4.0 documentation](https://github.com/Esri/esri-loader/blob/v1.4.0/README.md#usage) for how to use the callback-based API, but _keep in mind that these functions have been deprecated and will be removed at the next major release_.
+If there's already a Promise implementation loaded on the page you can configure esri-loader to use that implementation. For example, in [ember-esri-loader](https://github.com/Esri/ember-esri-loader), we configure esri-loader to use the RSVP Promise implementation included with Ember.js.
+
+```js
+  init () {
+    this._super(...arguments);
+    // have esriLoader use Ember's RSVP promise
+    esriLoader.utils.Promise = Ember.RSVP.Promise;
+  },
+```
+
+Otherwise, you should consider using a [Promise polyfill](https://www.google.com/search?q=promise+polyfill), ideally [only when needed](https://philipwalton.com/articles/loading-polyfills-only-when-needed/).
+
+Finally, for now you can still use `bootstrap()` and `dojoRequire()` which are the callback-based equivalents of the above functions. See the [v1.4.0 documentation](https://github.com/Esri/esri-loader/blob/v1.4.0/README.md#usage) for how to use the callback-based API, but _keep in mind that these functions have been deprecated and will be removed at the next major release_.
 
 ## Issues
 

--- a/karma.conf.js
+++ b/karma.conf.js
@@ -20,7 +20,8 @@ module.exports = function(config) {
     // list of files / patterns to load in the browser
     files: [
       builtFile,
-      'test/**/*.js'
+      'test/*.js',
+      { pattern: 'test/mocks/*.js', included: false }
     ],
 
 

--- a/src/esri-loader.ts
+++ b/src/esri-loader.ts
@@ -20,8 +20,9 @@ function getScript() {
 
 // TODO: at next breaking change replace the public isLoaded() API with this
 function _isLoaded() {
-  // TODO: instead of checking that require is defined, should this check if it is a function?
-  return typeof window['require'] !== 'undefined';
+  const globalRequire = window['require'];
+  // .on() ensures that it's Dojo's AMD loader
+  return globalRequire && globalRequire.on;
 }
 
 function createScript(url) {
@@ -73,7 +74,8 @@ export interface ILoadScriptOptions {
 
 // has ArcGIS API been loaded on the page yet?
 export function isLoaded() {
-  return _isLoaded() && getScript();
+  // TODO: replace this implementation with that of _isLoaded() on next major release
+  return typeof window['require'] !== 'undefined' && getScript();
 }
 
 // load the ArcGIS API on the page

--- a/src/esri-loader.ts
+++ b/src/esri-loader.ts
@@ -75,6 +75,11 @@ export interface IBootstrapOptions {
   dojoConfig?: { [propName: string]: any };
 }
 
+// allow consuming libraries to provide their own Promise implementations
+export const utils = {
+  Promise: window['Promise']
+};
+
 export interface ILoadScriptOptions {
   url?: string;
   // NOTE: stole the type definition for dojoConfig from:
@@ -96,7 +101,7 @@ export function loadScript(options: ILoadScriptOptions = {}): Promise<HTMLScript
     options.url = DEFAULT_URL;
   }
 
-  return new Promise((resolve, reject) => {
+  return new utils.Promise((resolve, reject) => {
     let script = getScript();
     if (script) {
       // the API is already loaded or in the process of loading...
@@ -146,7 +151,7 @@ export function loadScript(options: ILoadScriptOptions = {}): Promise<HTMLScript
 
 // wrap dojo's require() in a promise
 function requireModules(modules: string[]): Promise<any[]> {
-  return new Promise((resolve, reject) => {
+  return new utils.Promise((resolve, reject) => {
     // If something goes wrong loading the esri/dojo scripts, reject with the error.
     const errorHandler = window['require'].on('error', reject);
     window['require'](modules, (...args) => {
@@ -247,6 +252,7 @@ export default {
   isLoaded,
   loadScript,
   loadModules,
+  utils,
   // TODO: remove these the next major release
   bootstrap,
   dojoRequire

--- a/src/esri-loader.ts
+++ b/src/esri-loader.ts
@@ -139,8 +139,10 @@ export function loadScript(options: ILoadScriptOptions = {}): Promise<HTMLScript
 function requireModules(modules: string[]): Promise<any[]> {
   return new Promise((resolve, reject) => {
     // If something goes wrong loading the esri/dojo scripts, reject with the error.
-    window['require'].on('error', reject);
+    const errorHandler = window['require'].on('error', reject);
     window['require'](modules, (...args) => {
+      // remove error handler
+      errorHandler.remove();
       // Resolve with the parameters from dojo require as an array.
       resolve(args);
     });

--- a/src/esri-loader.ts
+++ b/src/esri-loader.ts
@@ -246,6 +246,7 @@ export function dojoRequire(modules: string[], callback: (...modules: any[]) => 
 export default {
   isLoaded,
   loadScript,
+  loadModules,
   // TODO: remove these the next major release
   bootstrap,
   dojoRequire

--- a/src/esri-loader.ts
+++ b/src/esri-loader.ts
@@ -11,6 +11,8 @@
   limitations under the License.
 */
 
+const DEFAULT_URL = 'https://js.arcgis.com/4.5/';
+
 // get the script injected by this library
 function getScript() {
   return document.querySelector('script[data-esri-loader]') as HTMLScriptElement;
@@ -22,9 +24,46 @@ function _isLoaded() {
   return typeof window['require'] !== 'undefined';
 }
 
+function createScript(url) {
+  const script = document.createElement('script');
+  script.type = 'text/javascript';
+  script.src = url;
+  // TODO: remove this if no longer needed
+  script.dataset['esriLoader'] = 'loading';
+  return script;
+}
+
+// add a one-time load handler to script
+function handleScriptLoad(script, callback) {
+  const onScriptLoad = () => {
+    // pass the script to the callback
+    callback(script);
+    // remove this event listener
+    script.removeEventListener('load', onScriptLoad, false);
+  };
+  script.addEventListener('load', onScriptLoad, false);
+}
+
+// add a one-time error handler to the script
+function handleScriptError(script, callback) {
+  const onScriptError = (e) => {
+    // reject the promise and remove this event listener
+    callback(e.error || new Error(`There was an error attempting to load ${script.src}`));
+    // remove this event listener
+    script.removeEventListener('error', onScriptError, false);
+  };
+  script.addEventListener('error', onScriptError, false);
+}
+
 // interfaces
-// TODO: rename to ILoadScriptOptions
+// TODO: remove this next breaking change
+// it has been replaced by ILoadScriptOptions
 export interface IBootstrapOptions {
+  url?: string;
+  dojoConfig?: { [propName: string]: any };
+}
+
+export interface ILoadScriptOptions {
   url?: string;
   // NOTE: stole the type definition for dojoConfig from:
   // https://github.com/nicksenger/esri-promise/blob/38834f22ffb3f70da3f57cce3773d168be990b0b/index.ts#L18
@@ -38,10 +77,10 @@ export function isLoaded() {
 }
 
 // load the ArcGIS API on the page
-export function loadScript(options: IBootstrapOptions = {}): Promise<HTMLScriptElement> {
+export function loadScript(options: ILoadScriptOptions = {}): Promise<HTMLScriptElement> {
   // default options
   if (!options.url) {
-    options.url = 'https://js.arcgis.com/4.5/';
+    options.url = DEFAULT_URL;
   }
 
   return new Promise((resolve, reject) => {
@@ -60,14 +99,9 @@ export function loadScript(options: IBootstrapOptions = {}): Promise<HTMLScriptE
           resolve(script);
         } else {
           // wait for the script to load and then resolve
-          script.addEventListener('load', () => {
-            // TODO: remove this event listener
-            resolve(script);
-          }, false);
-          script.addEventListener('error', (err) => {
-            // TODO: remove this event listener
-            reject(err);
-          }, false);
+          handleScriptLoad(script, resolve);
+          // handle script loading errors
+          handleScriptError(script, reject);
         }
       }
     } else {
@@ -82,19 +116,18 @@ export function loadScript(options: IBootstrapOptions = {}): Promise<HTMLScriptE
           window['dojoConfig'] = options.dojoConfig;
         }
         // create a script object whose source points to the API
-        script = document.createElement('script');
-        script.type = 'text/javascript';
-        script.src = options.url;
-        script.dataset['esriLoader'] = 'loading';
+        script = createScript(options.url);
         // once the script is loaded...
-        script.onload = () => {
+        // TODO: once we no longer need to update the dataset, replace this w/
+        // handleScriptLoad(script, resolve);
+        handleScriptLoad(script, () => {
           // update the status of the script
           script.dataset['esriLoader'] = 'loaded';
           // return the script
           resolve(script);
-        };
+        });
         // handle script loading errors
-        script.onerror = reject;
+        handleScriptError(script, reject);
         // load the script
         document.body.appendChild(script);
       }
@@ -105,31 +138,33 @@ export function loadScript(options: IBootstrapOptions = {}): Promise<HTMLScriptE
 // wrap dojo's require() in a promise
 function requireModules(modules: string[]): Promise<any[]> {
   return new Promise((resolve, reject) => {
-      // If something goes wrong loading the esri/dojo scripts, reject with the error.
-      window['require'].on('error', reject);
-      window['require'](modules, (...args) => {
-          // Resolve with the parameters from dojo require as an array.
-          resolve(args);
-      });
+    // If something goes wrong loading the esri/dojo scripts, reject with the error.
+    window['require'].on('error', reject);
+    window['require'](modules, (...args) => {
+      // Resolve with the parameters from dojo require as an array.
+      resolve(args);
+    });
   });
 }
 
 // returns a promise that resolves with an array of the required modules
 // also will attempt to lazy load the ArcGIS API if it has not already been loaded
-export function loadModules(modules: string[], loadScriptOptions?: IBootstrapOptions): Promise<any[]> {
+export function loadModules(modules: string[], loadScriptOptions?: ILoadScriptOptions): Promise<any[]> {
   if (!_isLoaded()) {
-    // script is not yet loaded, attept to load it
+    // script is not yet loaded, attept to load it then load the modules
     return loadScript(loadScriptOptions).then(() => requireModules(modules));
   } else {
+    // script is already loaded, just load the modules
     return requireModules(modules);
   }
 }
 
-// TODO: deprecate the following functions
+// TODO: remove this next major release
 export function bootstrap(callback?: (error: Error, dojoRequire?: any) => void, options: IBootstrapOptions = {}) {
+  console.warn('bootstrap() has been depricated and will be removed the next major release. Use loadScript() instead.');
   // default options
   if (!options.url) {
-    options.url = 'https://js.arcgis.com/4.5/';
+    options.url = DEFAULT_URL;
   }
 
   // don't reload API if it is already loaded or in the process of loading
@@ -146,10 +181,7 @@ export function bootstrap(callback?: (error: Error, dojoRequire?: any) => void, 
   }
 
   // create a script object whose source points to the API
-  const script = document.createElement('script');
-  script.type = 'text/javascript';
-  script.src = options.url;
-  script.dataset['esriLoader'] = 'loading';
+  const script = createScript(options.url);
 
   // once the script is loaded...
   script.onload = () => {
@@ -167,22 +199,20 @@ export function bootstrap(callback?: (error: Error, dojoRequire?: any) => void, 
     }
   };
 
-  // handle any script loading errors
-  const onScriptError = (e) => {
-    if (callback) {
-      // pass the error to the callback
-      callback(e.error || new Error(`There was an error attempting to load ${script.src}`));
-    }
-    // remove this event listener
-    script.removeEventListener('error', onScriptError, false);
-  };
-  script.addEventListener('error', onScriptError, false);
+  if (callback) {
+    // handle any script loading errors
+    handleScriptError(script, callback);
+  }
 
   // load the script
   document.body.appendChild(script);
 }
 
+// TODO: remove this next major release
 export function dojoRequire(modules: string[], callback: (...modules: any[]) => void) {
+  /* tslint:disable max-line-length */
+  console.warn('dojoRequire() has been depricated and will be removed the next major release. Use loadModules() instead.');
+  /* tslint:enable max-line-length */
   if (isLoaded()) {
     // already loaded, just call require
     window['require'](modules, callback);
@@ -191,11 +221,9 @@ export function dojoRequire(modules: string[], callback: (...modules: any[]) => 
     const script = getScript();
     if (script) {
       // Not yet loaded but script is in the body - use callback once loaded
-      const onScriptLoad = () => {
+      handleScriptLoad(script, () => {
         window['require'](modules, callback);
-        script.removeEventListener('load', onScriptLoad, false);
-      };
-      script.addEventListener('load', onScriptLoad, false);
+      });
     } else {
       // Not bootstrapped
       throw new Error('The ArcGIS API for JavaScript has not been loaded. You must first call esriLoader.bootstrap()');
@@ -207,7 +235,7 @@ export function dojoRequire(modules: string[], callback: (...modules: any[]) => 
 export default {
   isLoaded,
   loadScript,
-  // TODO: deprecate
+  // TODO: remove these the next major release
   bootstrap,
   dojoRequire
 };

--- a/test/esri-loader.spec.js
+++ b/test/esri-loader.spec.js
@@ -8,10 +8,9 @@ function stubRequire() {
     }
   }
   window.require.on = function(name, callback) {
-    // if (callback) {
-    //   // call the callback w/ the event name that was passed in
-    //   callback(name);
-    // }
+    return {
+      remove: function() {}
+    }
   }
 }
 // remove script tags added by esri-loader
@@ -241,7 +240,7 @@ describe('esri-loader', function () {
         stubRequire();
       });
       it('should have registered an error handler', function (done) {
-        spyOn(window.require, 'on');
+        spyOn(window.require, 'on').and.callThrough();
         esriLoader.loadModules(expectedModuleNames)
         .then(() => {
           expect(window.require.on.calls.argsFor(0)[0]).toEqual('error');

--- a/test/esri-loader.spec.js
+++ b/test/esri-loader.spec.js
@@ -53,8 +53,8 @@ describe('esri-loader', function () {
       var scriptEl;
       beforeAll(function (done) {
         spyOn(document.body, 'appendChild').and.callFake(function (el) {
-          // call the onload callback
-          el.onload();
+          // trigger the onload event listeners
+          el.dispatchEvent(new Event('load'));
         });
         esriLoader.loadScript()
         .then((script) => {
@@ -74,8 +74,8 @@ describe('esri-loader', function () {
       var scriptEl;
       beforeAll(function (done) {
         spyOn(document.body, 'appendChild').and.callFake(function (el) {
-          // call the onload callback
-          el.onload();
+          // trigger the onload event listeners
+          el.dispatchEvent(new Event('load'));
         });
         esriLoader.loadScript({
           url: 'https://js.arcgis.com/3.20'
@@ -88,6 +88,9 @@ describe('esri-loader', function () {
       });
       it('should load different version', function () {
         expect(scriptEl.src).toEqual('https://js.arcgis.com/3.20');
+      });
+      it('should not have set dojoConfig', function () {
+        expect(window.dojoConfig).not.toBeDefined();
       });
     });
     describe('with dojoConfig option', function () {
@@ -102,8 +105,8 @@ describe('esri-loader', function () {
       };
       beforeAll(function (done) {
         spyOn(document.body, 'appendChild').and.callFake(function (el) {
-          // call the onload callback
-          el.onload();
+          // trigger the onload event listeners
+          el.dispatchEvent(new Event('load'));
         });
         esriLoader.loadScript({
           dojoConfig: dojoConfig
@@ -138,6 +141,24 @@ describe('esri-loader', function () {
       afterAll(function () {
         // clean up
         removeRequire();
+      });
+    });
+    describe('when loading an invalid url', function () {
+      it('should pass an error to the callback', function (done) {
+        esriLoader.loadScript({
+          url: 'not a valid url'
+        })
+        .then(script => {
+          done.fail('call to loadScript should have failed');
+        })
+        .catch(err => {
+          expect(err.message.indexOf('There was an error attempting to load')).toEqual(0);
+          done();
+        });
+      });
+      afterAll(function () {
+        // clean up
+        removeScript();
       });
     });
     describe('when called twice', function () {
@@ -262,7 +283,8 @@ describe('esri-loader', function () {
         spyOn(document.body, 'appendChild').and.callFake(function (el) {
           stubRequire();
           spyOn(window, 'require').and.callThrough();
-          el.onload();
+          // trigger the onload event listeners
+          el.dispatchEvent(new Event('load'));
         });
         esriLoader.loadModules(expectedModuleNames, {
           url: jaspi3xUrl

--- a/test/mocks/jsapi3x.js
+++ b/test/mocks/jsapi3x.js
@@ -1,7 +1,3 @@
-// stub require function
-window.require = function (moduleNames, callback) {
-  if (callback) {
-    // call the callback w/ the modulenames that were passed in
-    callback.apply(this, moduleNames);
-  }
-}  
+// this is defined in spec
+console.log('3.x');
+stubRequire();

--- a/test/mocks/jsapi3x.js
+++ b/test/mocks/jsapi3x.js
@@ -1,0 +1,7 @@
+// stub require function
+window.require = function (moduleNames, callback) {
+  if (callback) {
+    // call the callback w/ the modulenames that were passed in
+    callback.apply(this, moduleNames);
+  }
+}  

--- a/test/mocks/jsapi4x.js
+++ b/test/mocks/jsapi4x.js
@@ -1,7 +1,3 @@
-// stub require function
-window.require = function (moduleNames, callback) {
-  if (callback) {
-    // call the callback w/ the modulenames that were passed in
-    callback.apply(this, moduleNames);
-  }
-}  
+// this is defined in spec
+console.log('4.x');
+stubRequire();

--- a/test/mocks/jsapi4x.js
+++ b/test/mocks/jsapi4x.js
@@ -1,0 +1,7 @@
+// stub require function
+window.require = function (moduleNames, callback) {
+  if (callback) {
+    // call the callback w/ the modulenames that were passed in
+    callback.apply(this, moduleNames);
+  }
+}  

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -3,6 +3,7 @@
     "declaration": true,
     "target": "es5",
     "module": "es2015",
+    "lib": ["dom", "es2015"],
     "sourceMap": true,
     "emitDecoratorMetadata": true,
     "experimentalDecorators": true,

--- a/tslint.json
+++ b/tslint.json
@@ -11,6 +11,7 @@
       }
     ],
     "object-literal-sort-keys": false,
-    "variable-name": [true, "check-format", "allow-leading-underscore"]
+    "variable-name": [true, "check-format", "allow-leading-underscore"],
+    "no-console": false
   }
 }


### PR DESCRIPTION
resolves #8 
resolves #28 

TODO: 
- [x] verify new API functions work in wrapper libs, or at least ember-esri-loader
- [x] ~can new promise-based methods can get rid of reliance on `data-esri-loader` on the script tag?~
- [x] remove error handlers when script/modules successfully load
