### PR TITLE
Fix/dist semver

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 ### Added
 ### Changed
 ### Fixed
+- re-include umd at dist root to avoid breaking apps w/ hardcoded path
 ### Removed
 ### Breaking
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 ### Added
 ### Changed
 - use rollup's uglify plugin for minified umd build
+- don't generate sourcemaps when compiling TypeScript
 ### Fixed
 - re-include umd at dist root to avoid breaking apps w/ hardcoded path
 ### Removed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 ## [Unreleased]
 ### Added
 ### Changed
+- use rollup's uglify plugin for minified umd build
 ### Fixed
 - re-include umd at dist root to avoid breaking apps w/ hardcoded path
 ### Removed

--- a/package.json
+++ b/package.json
@@ -13,15 +13,14 @@
   "types": "dist/esm/esri-loader.d.ts",
   "scripts": {
     "build": "tsc && rollup -c",
-    "build:release": "npm run clean && npm run build && rollup -c && npm run uglify",
+    "build:release": "npm run clean && npm run build && npm run build -- profiles/prod.config.js",
     "clean": "rm -rf dist && mkdir -p dist",
     "lint": "tslint -c tslint.json 'src/esri-loader.ts'",
     "prebuild": "npm run lint",
     "prepublish": "npm run build:release",
     "preversion": "npm run test && git add README.md CHANGELOG.md",
     "start": "npm run build && concurrently \"onchange 'src/esri-loader.ts' -- npm run build\" \"karma start\"",
-    "test": "npm run build:release && karma start --single-run=true",
-    "uglify": "uglifyjs ./dist/umd/esri-loader.js -m -c -o ./dist/umd/esri-loader.min.js --source-map ./dist/umd/esri-loader.min.js.map --source-map-url=esri-loader.min.js.map"
+    "test": "npm run build:release && karma start --single-run=true"
   },
   "repository": {
     "type": "git",
@@ -51,8 +50,8 @@
     "karma-mocha-reporter": "^2.2.3",
     "onchange": "^3.2.1",
     "rollup": "^0.41.6",
+    "rollup-plugin-uglify": "^2.0.1",
     "tslint": "^5.7.0",
-    "typescript": "^2.0.10",
-    "uglify-js": "^2.8.22"
+    "typescript": "^2.0.10"
   }
 }

--- a/package.json
+++ b/package.json
@@ -12,14 +12,18 @@
   "js:next": "dist/esm/esri-loader.js",
   "types": "dist/esm/esri-loader.d.ts",
   "scripts": {
-    "build": "tsc && rollup -c",
-    "build:release": "npm run clean && npm run build && npm run build -- profiles/prod.config.js",
+    "build": "npm run compile && npm run bundle",
+    "bundle": "rollup -c",
+    "build:release": "npm run build && npm run bundle -- profiles/prod.config.js",
+    "compile": "tsc",
     "clean": "rm -rf dist && mkdir -p dist",
     "lint": "tslint -c tslint.json 'src/esri-loader.ts'",
-    "prebuild": "npm run lint",
+    "postbuild:release": "npm run bundle -- --o dist/esri-loader.js && npm run bundle -- profiles/prod.config.js --o dist/esri-loader.min.js",
+    "prebuild:release": "npm run clean",
+    "precompile": "npm run lint",
     "prepublish": "npm run build:release",
     "preversion": "npm run test && git add README.md CHANGELOG.md",
-    "start": "npm run build && concurrently \"onchange 'src/esri-loader.ts' -- npm run build\" \"karma start\"",
+    "start": "npm run clean && npm run build && concurrently \"onchange 'src/esri-loader.ts' -- npm run build\" \"karma start\"",
     "test": "npm run build:release && karma start --single-run=true"
   },
   "repository": {

--- a/profiles/base.config.js
+++ b/profiles/base.config.js
@@ -1,0 +1,8 @@
+export default {
+  entry: 'dist/esm/esri-loader.js',
+  format: 'umd',
+  moduleName: 'esriLoader',
+  exports: 'named',
+  dest: 'dist/umd/esri-loader.js',
+  sourceMap: true
+};

--- a/profiles/prod.config.js
+++ b/profiles/prod.config.js
@@ -1,0 +1,9 @@
+import uglify from 'rollup-plugin-uglify';
+import base from './base.config.js';
+
+export default Object.assign({}, base, {
+  dest: 'dist/umd/esri-loader.min.js',
+  plugins: [
+    uglify()
+  ]
+});

--- a/rollup.config.js
+++ b/rollup.config.js
@@ -1,8 +1,3 @@
-export default {
-  entry: 'dist/esm/esri-loader.js',
-  format: 'umd',
-  moduleName: 'esriLoader',
-  exports: 'named',
-  dest: 'dist/umd/esri-loader.js',
-  sourceMap: 'dist/umd/esri-loader.js.map'
-};
+import base from './profiles/base.config.js';
+
+export default base;

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -4,7 +4,6 @@
     "target": "es5",
     "module": "es2015",
     "lib": ["dom", "es2015"],
-    "sourceMap": true,
     "emitDecoratorMetadata": true,
     "experimentalDecorators": true,
     "removeComments": false,


### PR DESCRIPTION
Resolves #56 

Also fixes sourcemaps so they don't point to files that are not included in the bundle.

NOTE: the "postbuild:release" npm script should be removed at the next major release.