### PR TITLE
fallback to current url when loading modules

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 - remove remaining references to angular-esri-loader from README
 - update README w/ info on arcgis types and browser support
 ### Fixed
+- fallback to current url when loading modules
 ### Removed
 ### Breaking
 

--- a/src/esri-loader.ts
+++ b/src/esri-loader.ts
@@ -13,6 +13,9 @@
 
 const DEFAULT_URL = 'https://js.arcgis.com/4.6/';
 
+// this is the url that is currently being, or already has loaded
+let _currentUrl;
+
 // get the script injected by this library
 function getScript() {
   return document.querySelector('script[data-esri-loader]') as HTMLScriptElement;
@@ -133,6 +136,7 @@ export function loadScript(options: ILoadScriptOptions = {}): Promise<HTMLScript
         }
         // create a script object whose source points to the API
         script = createScript(options.url);
+        _currentUrl = options.url;
         // once the script is loaded...
         // TODO: once we no longer need to update the dataset, replace this w/
         // handleScriptLoad(script, resolve, reject);
@@ -165,9 +169,14 @@ function requireModules(modules: string[]): Promise<any[]> {
 
 // returns a promise that resolves with an array of the required modules
 // also will attempt to lazy load the ArcGIS API if it has not already been loaded
-export function loadModules(modules: string[], loadScriptOptions?: ILoadScriptOptions): Promise<any[]> {
+export function loadModules(modules: string[], loadScriptOptions: ILoadScriptOptions = {}): Promise<any[]> {
   if (!_isLoaded()) {
-    // script is not yet loaded, attept to load it then load the modules
+    // script is not yet loaded
+    if (!loadScriptOptions.url && _currentUrl) {
+      // alredy in the process of loading, so default to the same url
+      loadScriptOptions.url = _currentUrl;
+    }
+    // attept to load the script then load the modules
     return loadScript(loadScriptOptions).then(() => requireModules(modules));
   } else {
     // script is already loaded, just load the modules


### PR DESCRIPTION
resolves #61 
resolves #51

I made these changes a while back. I actually had [originally tried using a singleton promise](https://github.com/Esri/esri-loader/compare/8dc3b0219c99c3c6d4291ba9dbe3a5e245b42274...fix/singleton-promise) instead of holding onto `_currentUrl` like I do in this PR. However, I ended up having to expose that singleton promise (as `esriLoader._loadModulesPromise`) so that I could clear the state between tests. I didn't like that, so I started on the approach in this PR.

TBH I couldn't get the tests to pass in this branch either so I just dropped it and planned to revisit it in a couple of days. Those days turned into weeks, and I just revisited it today, [removed one line from the test spec](https://github.com/Esri/esri-loader/compare/fix/current-url?expand=1#diff-2433b2d05460c978cc90b48ace187643L302) and got the tests passing. The actual logic of the changes to the source code looks sound to me, but I haven't wrapped my head around whether or not the new tests in this PR are valid. I _think_ they are, but [this commented out `setTimeout`](https://github.com/Esri/esri-loader/compare/fix/current-url?expand=1#diff-2433b2d05460c978cc90b48ace187643R306) worries me even though the tests pass when I uncomment those lines.

Anyway, I will try to repro the issue in #61 in an app and then `npm link` this branch and see if that resolves it. If it does, I say we merge this and :shipit:.

Until then, I wanted to open this PR to have at least @veonline to be able to review the logic/tests.
