### PR TITLE
fix window undefined error in server-rendered apps

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,10 +4,12 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [Unreleased]
 ### Added
+- default to version 4.6 of the ArcGIS API [#63](https://github.com/Esri/esri-loader/issues/63)
 ### Changed
 - remove remaining references to angular-esri-loader from README
-- update README w/ info on arcgis types and browser support
+- update README w/ info on arcgis types and browser support [#60](https://github.com/Esri/esri-loader/issues/60)
 ### Fixed
+- window undefined error in server-rendered apps [#64](https://github.com/Esri/esri-loader/issues/64)
 ### Removed
 ### Breaking
 

--- a/src/esri-loader.ts
+++ b/src/esri-loader.ts
@@ -10,7 +10,7 @@
   See the License for the specific language governing permissions and
   limitations under the License.
 */
-
+const isBrowser = typeof window !== 'undefined';
 const DEFAULT_URL = 'https://js.arcgis.com/4.6/';
 
 // get the script injected by this library
@@ -77,7 +77,7 @@ export interface IBootstrapOptions {
 
 // allow consuming libraries to provide their own Promise implementations
 export const utils = {
-  Promise: window['Promise']
+  Promise: isBrowser ? window['Promise'] : undefined
 };
 
 export interface ILoadScriptOptions {


### PR DESCRIPTION
resolves #64

I've confirmed that this fixes the issue by running npm-linked in a server-rendered app as  @tgeorges suggested here: https://github.com/Esri/esri-loader/issues/64#issuecomment-353637373
