### PR TITLE
`loadScript()` takes a `css` option to load stylesheet by URL

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [Unreleased]
 ### Added
+- `loadScript()` takes a `css` option to load stylesheet by URL
 ### Changed
 ### Fixed
 ### Removed

--- a/src/esri-loader.ts
+++ b/src/esri-loader.ts
@@ -66,7 +66,7 @@ function handleScriptError(script, callback) {
 // interfaces
 export interface ILoadScriptOptions {
   url?: string;
-  // TODO: css?: string;
+  css?: string;
   dojoConfig?: { [propName: string]: any };
 }
 
@@ -136,6 +136,10 @@ export function loadScript(options: ILoadScriptOptions = {}): Promise<HTMLScript
         reject(new Error(`The ArcGIS API for JavaScript is already loaded.`));
       } else {
         // this is the first time attempting to load the API
+        if (options.css) {
+          // load the css before loading the script
+          loadCss(options.css);
+        }
         if (options.dojoConfig) {
           // set dojo configuration parameters before loading the script
           window['dojoConfig'] = options.dojoConfig;

--- a/test/esri-loader.spec.js
+++ b/test/esri-loader.spec.js
@@ -84,6 +84,7 @@ describe('esri-loader', function () {
           // trigger the onload event listeners
           el.dispatchEvent(new Event('load'));
         });
+        spyOn(document.head, 'appendChild');
         esriLoader.loadScript()
         .then((script) => {
           // hold onto script element for assertions below
@@ -96,6 +97,9 @@ describe('esri-loader', function () {
       });
       it('should not have set dojoConfig', function () {
         expect(window.dojoConfig).not.toBeDefined();
+      });
+      it('should not have called loadCss', function () {
+        expect(document.head.appendChild.calls.any()).toBeFalsy();
       });
     });
     describe('with different API version', function () {
@@ -119,6 +123,25 @@ describe('esri-loader', function () {
       });
       it('should not have set dojoConfig', function () {
         expect(window.dojoConfig).not.toBeDefined();
+      });
+    });
+    describe('with css option', function () {
+      var cssUrl = 'https://js.arcgis.com/4.6/esri/css/main.css';
+      beforeAll(function (done) {
+        spyOn(document.body, 'appendChild').and.callFake(function (el) {
+          // trigger the onload event listeners
+          el.dispatchEvent(new Event('load'));
+        });
+        spyOn(document.head, 'appendChild').and.stub();
+        esriLoader.loadScript({
+          css: cssUrl
+        })
+        .then((script) => {
+          done();
+        });
+      });
+      it('should have called loadCss with the url', function () {
+        expect(document.head.appendChild.calls.argsFor(0)[0].href).toEqual(cssUrl);
       });
     });
     describe('with dojoConfig option', function () {


### PR DESCRIPTION
- Describe the proposed changes:

`loadScript()` now takes a `css` option that is a URL (string) and (if present) passes that to `loadCss()` to load a stylesheet by URL

  - Is there an example or test page to demonstrate any new or changed features?

not yet

  - Does your PR include appropriate tests for source code alterations?

yes

  - If you're adding or changing a public API, did you update the docs Usage sections of the README? If not, please provide a code snippet that demonstrates how to consume the new or updated API(s).

not yet. Basically, it's either `loadScript({ css: cssUrl })` or `loadModules(['esri/map'], { css: cssUrl })`, but it seems like it's going to be tricky to figure out how that fits into the README, and I may have had too much 🍷to deal w/ that at this hour.

- Provide a reference to any related issue.

yet another step towards resolving #6 
