### PR TITLE
update ArcGIS API version 4.6 -> 4.7 and 3.23 -> 3.24

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,23 +34,23 @@ The code snippets below show how to load the ArcGIS API and its modules and then
 Before you can use the ArcGIS API in your app, you'll need to load the styles that correspond to the version you are using. You can use the provided `loadCss(url)` function. For example:
 
 ```js
-// load esri styles for version 4.6 using loadCss
-esriLoader.loadCss('https://js.arcgis.com/4.6/esri/css/main.css');
+// load esri styles for version 4.7 using loadCss
+esriLoader.loadCss('https://js.arcgis.com/4.7/esri/css/main.css');
 ```
 
 Alternatively, you can manually load them by more traditional means such as adding `<link>` tags to your HTML, or `@import` statements to your CSS. For example:
 
 ```html
-<!-- load esri styles for version 4.6 via a link tag -->
-<link rel="stylesheet" href="https://js.arcgis.com/4.6/esri/css/main.css">
-@import url('https://js.arcgis.com/4.6/esri/css/main.css');
+<!-- load esri styles for version 4.7 via a link tag -->
+<link rel="stylesheet" href="https://js.arcgis.com/4.7/esri/css/main.css">
+@import url('https://js.arcgis.com/4.7/esri/css/main.css');
 ```
 
 or:
 
 ```css
-/* load esri styles for version 3.23 via import */
-@import url('https://js.arcgis.com/3.23/esri/css/esri.css');
+/* load esri styles for version 3.24 via import */
+@import url('https://js.arcgis.com/3.24/esri/css/esri.css');
 ```
 
 ### Loading Modules from the ArcGIS API for JavaScript
@@ -90,7 +90,7 @@ If you don't want to use the latest version of the ArcGIS API hosted on Esri's C
 // loadModules() will call loadScript() and pass these options, which, 
 // in this case are only needed b/c we're using v3.x instead of the latest 4.x
 const options = {
-  url: 'https://js.arcgis.com/3.23/'
+  url: 'https://js.arcgis.com/3.24/'
 };
 esriLoader.loadModules(['esri/map'], options)
 .then(([Map]) => {
@@ -256,7 +256,7 @@ It is possible to use this library only to load modules (i.e. not to pre-load or
 
 ```html
 <!-- index.html -->
-<script src="https://js.arcgis.com/3.23/" data-esri-loader="loaded"></script>
+<script src="https://js.arcgis.com/3.24/" data-esri-loader="loaded"></script>
 ```
 
 ### ArcGIS Types

--- a/src/esri-loader.ts
+++ b/src/esri-loader.ts
@@ -13,7 +13,7 @@
 import { loadCss } from './utils/css';
 
 const isBrowser = typeof window !== 'undefined';
-const DEFAULT_URL = 'https://js.arcgis.com/4.6/';
+const DEFAULT_URL = 'https://js.arcgis.com/4.7/';
 // this is the url that is currently being, or already has loaded
 let _currentUrl;
 

--- a/test/esri-loader.spec.js
+++ b/test/esri-loader.spec.js
@@ -39,7 +39,7 @@ describe('esri-loader', function () {
 
   describe('when loading the css', function () {
     describe('with a url', function () {
-      var url = 'https://js.arcgis.com/4.6/esri/css/main.css';
+      var url = 'https://js.arcgis.com/4.7/esri/css/main.css';
       var link;
       beforeAll(function () {
         spyOn(document.head, 'appendChild').and.stub();
@@ -58,7 +58,7 @@ describe('esri-loader', function () {
     });
     describe('when called twice', function () {
       describe('when loading the same url', function () {
-        var url = 'https://js.arcgis.com/4.6/esri/css/main.css';
+        var url = 'https://js.arcgis.com/4.7/esri/css/main.css';
         var link, link2;
         beforeAll(function () {
           spyOn(document.head, 'appendChild').and.stub();
@@ -93,7 +93,7 @@ describe('esri-loader', function () {
         });
       });
       it('should default to latest version', function () {
-        expect(scriptEl.src).toEqual('https://js.arcgis.com/4.6/');
+        expect(scriptEl.src).toEqual('https://js.arcgis.com/4.7/');
       });
       it('should not have set dojoConfig', function () {
         expect(window.dojoConfig).not.toBeDefined();
@@ -110,7 +110,7 @@ describe('esri-loader', function () {
           el.dispatchEvent(new Event('load'));
         });
         esriLoader.loadScript({
-          url: 'https://js.arcgis.com/3.23'
+          url: 'https://js.arcgis.com/3.24'
         })
         .then((script) => {
           // hold onto script element for assertions below
@@ -119,14 +119,14 @@ describe('esri-loader', function () {
         });
       });
       it('should load different version', function () {
-        expect(scriptEl.src).toEqual('https://js.arcgis.com/3.23');
+        expect(scriptEl.src).toEqual('https://js.arcgis.com/3.24');
       });
       it('should not have set dojoConfig', function () {
         expect(window.dojoConfig).not.toBeDefined();
       });
     });
     describe('with css option', function () {
-      var cssUrl = 'https://js.arcgis.com/4.6/esri/css/main.css';
+      var cssUrl = 'https://js.arcgis.com/4.7/esri/css/main.css';
       beforeAll(function (done) {
         spyOn(document.body, 'appendChild').and.callFake(function (el) {
           // trigger the onload event listeners


### PR DESCRIPTION
A simple search and replace addressing this issue: https://github.com/Esri/esri-loader/issues/104

I updated the `DEFAULT_URL` and also the README.

`npm run test` passes 100%.