### PR TITLE
export missing ILoadScriptOptions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 ### Added
 ### Changed
 ### Fixed
+- export missing ILoadScriptOptions
 ### Removed
 ### Breaking
 

--- a/src/esri-loader.ts
+++ b/src/esri-loader.ts
@@ -17,6 +17,7 @@ import { getScript, isLoaded, loadScript } from './script';
 import { loadCss } from './utils/css';
 import utils from './utils/index';
 export { getScript, isLoaded, loadModules, loadScript, loadCss, utils };
+export { ILoadScriptOptions } from './script';
 
 // NOTE: rollup ignores the default export
 // and builds the UMD namespace out of the above named exports


### PR DESCRIPTION
- Describe the proposed changes:

When I moved code into modules, I forgot to re-export the ILoadScriptOptions interface. This fixes that.

  - Is there an example or test page to demonstrate any new or changed features?

no

  - Does your PR include appropriate tests for source code alterations?

no

  - If you're adding or changing a public API, did you update the docs Usage sections of the README?

n/a

- Provide a reference to any related issue.

resolves #166 

