### PR TITLE
Fix window undefined in Node environments

### DIFF
--- a/src/utils/index.ts
+++ b/src/utils/index.ts
@@ -1,7 +1,9 @@
 /* Copyright (c) 2017 Environmental Systems Research Institute, Inc.
  * Apache-2.0 */
 
+const isBrowser = typeof window !== 'undefined';
+
 // allow consuming libraries to provide their own Promise implementations
 export default {
-  Promise: window && window['Promise']
+  Promise: isBrowser ? window['Promise'] : undefined
 };


### PR DESCRIPTION
In node environments (when esri-loader is used in a SSR app), Node throws the following error:
```sh
ReferenceError: window is not defined
```

Adding back the correct `typeof` check from a previous commit that did not fail: https://github.com/Esri/esri-loader/commit/3145419df900b9713e65ae77f56f2dded30f7dd2#diff-2cfb1554a9cbe2bf7981031a26f82e4eL5