### PR TITLE
add support for "next" version

### DIFF
--- a/README.md
+++ b/README.md
@@ -119,6 +119,8 @@ loadModules(['esri/map'], options)
   });
 ```
 
+You can load the ["next" version of the ArcGIS API](https://github.com/Esri/feedback-js-api-next#esri-loader) by passing `next` as the version.
+
 ### From a Specific URL
 
 You can also load the modules from a specific URL, for example from a version of the SDK that you host on your own server. In this case, instead of passing the `version` option, you would pass the URL as a string like:

--- a/src/utils/css.test.ts
+++ b/src/utils/css.test.ts
@@ -37,6 +37,24 @@ describe('when loading the css', () => {
       expect(link.rel).toEqual('stylesheet');
     });
   });
+  describe('with "next"', () => {
+    const url = 'https://js.arcgis.com/next/esri/css/main.css';
+    let link;
+    beforeAll(() => {
+      spyOn(document.head, 'appendChild').and.stub();
+      spyOn(document, 'querySelector');
+      link = loadCss('next');
+    });
+    it('should have checked if the link was already appended', () => {
+      expect((document.querySelector as jasmine.Spy).calls.argsFor(0)[0]).toEqual(`link[href*="${url}"]`);
+    });
+    it('should have set the href', () => {
+      expect(link.href).toEqual(url);
+    });
+    it('should not have set the rel', () => {
+      expect(link.rel).toEqual('stylesheet');
+    });
+  });
   describe('with a url', () => {
     const url = 'http://server/path/to/esri/css/main.css';
     let link;

--- a/src/utils/css.test.ts
+++ b/src/utils/css.test.ts
@@ -38,7 +38,7 @@ describe('when loading the css', () => {
     });
   });
   describe('with "next"', () => {
-    const url = 'https://js.arcgis.com/next/esri/css/main.css';
+    const url = 'https://js.arcgis.com/next/esri/themes/light/main.css';
     let link;
     beforeAll(() => {
       spyOn(document.head, 'appendChild').and.stub();

--- a/src/utils/url.ts
+++ b/src/utils/url.ts
@@ -2,8 +2,13 @@
  * Apache-2.0 */
 
 const DEFAULT_VERSION = '4.12';
+const NEXT = 'next';
 
 export function parseVersion(version) {
+  if (version.toLowerCase() === NEXT) {
+    return NEXT;
+  }
+
   const match = version && version.match(/^(\d)\.(\d+)/);
   return match && {
     major: parseInt(match[1], 10),
@@ -23,12 +28,12 @@ export function getCdnUrl(version = DEFAULT_VERSION) {
 /**
  * Get the CDN url for a the CSS for a given version and/or theme
  *
- * @param version Ex: '4.12' or '3.29'. Defaults to the latest 4.x version.
+ * @param version Ex: '4.12', '3.29', or 'next'. Defaults to the latest 4.x version.
  */
 export function getCdnCssUrl(version = DEFAULT_VERSION) {
   const baseUrl = getCdnUrl(version);
   const parsedVersion = parseVersion(version);
-  if (parsedVersion.major === 3) {
+  if (parsedVersion !== NEXT && parsedVersion.major === 3) {
     // NOTE: at 3.11 the CSS moved from the /js folder to the root
     const path = parsedVersion.minor <= 10 ? 'js/' : '';
     return `${baseUrl}${path}esri/css/esri.css`;


### PR DESCRIPTION
Add support for using the [next](https://github.com/Esri/feedback-js-api-next) version of the Esri JS API.

- [ ] If this PR is accepted, [the README for esri/feedback-js-api-next](https://github.com/Esri/feedback-js-api-next#esri-loader) also need to be updated.

This almost certainly has conflicts with #187 but I wanted to keep them separate. I'm happy to resolve them if the maintainers approve of both PRs. I could resubmit a new PR with both or add one to the other.