### PR TITLE
Update README Map Reference to 'esri/Map'

### DIFF
--- a/README.md
+++ b/README.md
@@ -395,7 +395,7 @@ import { loadModules } from 'esri-loader';
 // and the CSS for that version from the ArcGIS CDN
 const options = { version: '3.32', css: true };
 
-loadModules(['esri/map'], options)
+loadModules(['esri/Map'], options)
   .then(([Map]) => {
     // create map with the given options at a DOM node w/ id 'mapNode'
     let map = new Map('mapNode', {


### PR DESCRIPTION
Replaces 'esri/map' reference with 'esri/Map' as the esri-loader is case-sensitive and the previous reference will result in a 404 error.
