### PR TITLE
default to ArcGIS API for JavaScript version 4.19

### DIFF
--- a/README.md
+++ b/README.md
@@ -109,9 +109,9 @@ For example, the snippet below configures esri-loader to use the [latest 3.x rel
 // app.js
 import { setDefaultOptions } from 'esri-loader';
 
-// configure esri-loader to use version 3.35 from the ArcGIS CDN
+// configure esri-loader to use version 3.36 from the ArcGIS CDN
 // NOTE: make sure this is called once before any calls to loadModules()
-setDefaultOptions({ version: '3.35' })
+setDefaultOptions({ version: '3.36' })
 ```
 
 Then later, for example after a map component has mounted, you would use `loadModules()` as normal, except in this case you'd be using the [3.x `Map` class](https://developers.arcgis.com/javascript/3/jsapi/map-amd.html) instead of the 4.x classes.
@@ -195,7 +195,7 @@ import { loadCss } from 'esri-loader';
 loadCss();
 
 // or for a specific CDN version
-loadCss('3.35');
+loadCss('3.36');
 
 // or a from specific URL, like a locally hosted version
 loadCss('http://server/path/to/esri/css/main.css');
@@ -398,7 +398,7 @@ As mentioned above, you can call `setDefaultOptions()` to configure [how esri-lo
 
 | Name | Type | Default Value | Description |
 | -- | -- | -- | -- |
-| `version` | `string` | `'4.18'` | The version of the ArcGIS API hosted on Esri's CDN to use. |
+| `version` | `string` | `'4.19'` | The version of the ArcGIS API hosted on Esri's CDN to use. |
 | `url` | `string` | `undefined` | The URL to a hosted build of the ArcGIS API to use. If both `version` and `url` are passed, `url` will be used. |
 | `css` | `string` or `boolean` | `undefined` | If a `string` is passed it is assumed to be the URL of a CSS file to load. Use `css: true` to load the `version`'s CSS from the CDN. |
 | `insertCssBefore` | `string` | `undefined` | When using `css`, the `<link>` to the stylesheet will be inserted before the first element that matches this [CSS Selector](https://developer.mozilla.org/en-US/docs/Web/CSS/CSS_Selectors). See [Overriding ArcGIS Styles](#overriding-arcgis-styles). |
@@ -412,9 +412,9 @@ If your application only has a single call to `loadModules()`, you do not need `
 ```js
 import { loadModules } from 'esri-loader';
 
-// configure esri-loader to use version 3.35
+// configure esri-loader to use version 3.36
 // and the CSS for that version from the ArcGIS CDN
-const options = { version: '3.35', css: true };
+const options = { version: '3.36', css: true };
 
 loadModules(['esri/map'], options)
   .then(([Map]) => {
@@ -509,7 +509,7 @@ It is possible to use this library only to load modules (i.e. not to lazy load o
 
 ```html
 <!-- index.html -->
-<script src="https://js.arcgis.com/4.18/" data-esri-loader="loaded"></script>
+<script src="https://js.arcgis.com/4.19/" data-esri-loader="loaded"></script>
 ```
 
 ### Without a module bundler

--- a/src/script.test.ts
+++ b/src/script.test.ts
@@ -57,7 +57,7 @@ describe('when loading the script', function() {
       });
     });
     it('should default to latest version', function() {
-      expect(scriptEl.src).toEqual('https://js.arcgis.com/4.18/');
+      expect(scriptEl.src).toEqual('https://js.arcgis.com/4.19/');
     });
     it('should not have called loadCss', function() {
       expect((cssUtils.loadCss as jasmine.Spy).calls.any()).toBeFalsy();
@@ -94,12 +94,12 @@ describe('when loading the script', function() {
     });
   });
   describe('with a specific version from the CDN', function() {
-    const expected = 'https://js.arcgis.com/3.35/';
+    const expected = 'https://js.arcgis.com/3.36/';
     let scriptEl;
     beforeAll(function(done) {
       fakeLoading();
       loadScript({
-        version: '3.35'
+        version: '3.36'
       })
       .then((script) => {
         // hold onto script element for assertions below
@@ -145,7 +145,7 @@ describe('when loading the script', function() {
       });
     });
     describe('with a specific version from the CDN', () => {
-      const version = '3.35';
+      const version = '3.36';
       beforeAll(function(done) {
         fakeLoading();
         loadScript({

--- a/src/utils/css.test.ts
+++ b/src/utils/css.test.ts
@@ -2,7 +2,7 @@ import { loadCss } from './css';
 
 describe('when loading the css', () => {
   describe('with no arguments', () => {
-    const url = 'https://js.arcgis.com/4.18/esri/themes/light/main.css';
+    const url = 'https://js.arcgis.com/4.19/esri/themes/light/main.css';
     let link;
     beforeAll(() => {
       spyOn(document.head, 'appendChild').and.stub();
@@ -75,7 +75,7 @@ describe('when loading the css', () => {
   });
   describe('when called twice', () => {
     describe('when loading the same url', () => {
-      const url = 'https://js.arcgis.com/4.18/esri/themes/light/main.css';
+      const url = 'https://js.arcgis.com/4.19/esri/themes/light/main.css';
       let link;
       let link2;
       beforeAll(() => {
@@ -93,7 +93,7 @@ describe('when loading the css', () => {
     });
   });
   describe('when inserting before an existing node', () => {
-    const url = 'https://js.arcgis.com/4.18/esri/themes/light/main.css';
+    const url = 'https://js.arcgis.com/4.19/esri/themes/light/main.css';
     // insert before the first <style> tag
     const before = 'style';
     let link;

--- a/src/utils/url.test.ts
+++ b/src/utils/url.test.ts
@@ -4,12 +4,12 @@ describe ('when getting CDN URLs', () => {
   describe('for the script', () => {
     describe('with no arguments', () => {
       it('should default to latest 4.x URL', () => {
-        expect(getCdnUrl()).toEqual('https://js.arcgis.com/4.18/');
+        expect(getCdnUrl()).toEqual('https://js.arcgis.com/4.19/');
       });
     });
     describe('with a valid version', () => {
       it('should return URL for that version', () => {
-        expect(getCdnUrl('3.35')).toEqual('https://js.arcgis.com/3.35/');
+        expect(getCdnUrl('3.36')).toEqual('https://js.arcgis.com/3.36/');
       });
     });
     // TODO: what about an invalid version? should we throw?
@@ -17,12 +17,12 @@ describe ('when getting CDN URLs', () => {
   describe('for the CSS', () => {
     describe('with no arguments', () => {
       it('should default to the latest 4.x CSS URL', () => {
-        expect(getCdnCssUrl()).toEqual('https://js.arcgis.com/4.18/esri/themes/light/main.css');
+        expect(getCdnCssUrl()).toEqual('https://js.arcgis.com/4.19/esri/themes/light/main.css');
       });
     });
     describe('for 3.x version >= 3.11', () => {
       it('should return the CSS URL for that version', () => {
-        expect(getCdnCssUrl('3.35')).toEqual('https://js.arcgis.com/3.35/esri/css/esri.css');
+        expect(getCdnCssUrl('3.36')).toEqual('https://js.arcgis.com/3.36/esri/css/esri.css');
       });
     });
     describe('for version < 3.11', () => {

--- a/src/utils/url.ts
+++ b/src/utils/url.ts
@@ -1,7 +1,7 @@
 /* Copyright (c) 2017 Environmental Systems Research Institute, Inc.
  * Apache-2.0 */
 
-const DEFAULT_VERSION = '4.18';
+const DEFAULT_VERSION = '4.19';
 const NEXT = 'next';
 
 export function parseVersion(version) {
@@ -19,7 +19,7 @@ export function parseVersion(version) {
 /**
  * Get the CDN url for a given version
  *
- * @param version Ex: '4.18' or '3.35'. Defaults to the latest 4.x version.
+ * @param version Ex: '4.19' or '3.36'. Defaults to the latest 4.x version.
  */
 export function getCdnUrl(version = DEFAULT_VERSION) {
   return `https://js.arcgis.com/${version}/`;
@@ -28,7 +28,7 @@ export function getCdnUrl(version = DEFAULT_VERSION) {
 /**
  * Get the CDN url for a the CSS for a given version and/or theme
  *
- * @param version Ex: '4.18', '3.35', or 'next'. Defaults to the latest 4.x version.
+ * @param version Ex: '4.19', '3.36', or 'next'. Defaults to the latest 4.x version.
  */
 export function getCdnCssUrl(version = DEFAULT_VERSION) {
   const baseUrl = getCdnUrl(version);


### PR DESCRIPTION
hi @tomwayson, @jwasilgeo 

Here is my commit to upgrade the default version of JSAPI from 4.18 to 4.19.

Thanks,
Jinnan