### PR TITLE
SDK Rename

### DIFF
--- a/.github/ISSUE_TEMPLATE.md
+++ b/.github/ISSUE_TEMPLATE.md
@@ -21,6 +21,6 @@ Please provide:
 
 To help you reproduce issues in an environment that we can't access (e.g. private repository) follow these helpful tips:
 
-- If the problem is related to the ArcGIS API (i.e. behavior of the map, etc), start here https://github.com/Esri/esri-loader#without-a-module-bundler.
+- If the problem is related to the ArcGIS Maps SDK for JavaScript (i.e. behavior of the map, etc), start here https://github.com/Esri/esri-loader#without-a-module-bundler.
 - Otherwise, search for and fork a codesandbox that is similar to your environment (React, etc): https://codesandbox.io/search
   - For sandboxes that depend on esri-loader see: https://codesandbox.io/search?refinementList[npm_dependencies.dependency][0]=esri-loader

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,14 +11,14 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [3.7.0] - 2022-11-16
 ### Added
-- default to JS SDK 4.25; update docs w/ latest version numbers - @andygup
+- default to 4.25; update docs w/ latest version numbers - @andygup
 ### Changed
 - raise visibility of deprecation notice for frameworks that do not support async/await at runtime, e.g. Angular due to limitations in Zone.js
 - archive framework samples and various 3.x-related sections to archived-examples.md. Most of the samples haven't been updated in years
 
 ## [3.6.0] - 2022-07-07
 ### Added
-- default to JS SDK 4.24; update docs w/ latest version numbers - @gavinr
+- default to 4.24; update docs w/ latest version numbers - @gavinr
 
 ### Changed
 - fix build by not compiling @types
@@ -27,11 +27,11 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [3.5.0] - 2022-03-29
 ### Added
-- default to JS SDK 4.23; update docs w/ latest version numbers - @gavinr
+- default to 4.23; update docs w/ latest version numbers - @gavinr
 
 ## [3.4.0] - 2022-01-14
 ### Added
-- default to JS SDK 4.22; update docs w/ latest version numbers - @gavinr
+- default to 4.22; update docs w/ latest version numbers - @gavinr
 
 ## [3.3.0] - 2021-09-22
 
@@ -41,33 +41,33 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [3.1.0] - 2021-04-23
 ### Added
-- default to JS SDK 4.19; update docs w/ latest version numbers - @vannizhang
+- default to 4.19; update docs w/ latest version numbers - @vannizhang
 
 ## [3.0.0] - 2020-12-31
 ### Added
-- default to JS SDK 4.18; update docs w/ latest version numbers - @gavinr
+- default to 4.18; update docs w/ latest version numbers - @gavinr
 
 ### Breaking
-- default version of JS SDK no longer supports IE
+- 4.18 no longer supports IE
 - remove option to set `dojoConfig`
 - remove esri-loader default export
 
 ## [2.16.0] - 2020-10-13
 ### Added
-- default to JS SDK 4.17; update docs w/ latest version numbers - @tgirgin23
+- default to 4.17; update docs w/ latest version numbers - @tgirgin23
 
 ## [2.15.0] - 2020-07-10
 ### Added
-- default to JS SDK 4.16; update docs w/ latest version numbers - @JoshCrozier
+- default to 4.16; update docs w/ latest version numbers - @JoshCrozier
 
 ## [2.14.0] - 2020-04-09
 ### Added
-- default to JS SDK 4.15; update docs w/ latest version numbers - @JoshCrozier
+- default to 4.15; update docs w/ latest version numbers - @JoshCrozier
 
 ## [2.13.0] - 2019-12-22
 
 ### Added
-- default to JS SDK 4.14; update docs w/ latest version numbers - @gpbmike
+- default to 4.14; update docs w/ latest version numbers - @gpbmike
 
 ## [2.12.0] - 2019-10-24
 
@@ -78,8 +78,8 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [2.11.0] - 2019-10-14
 ### Added
-- default to JS SDK 4.13; update docs w/ latest version numbers
-- add support for "next" version of JS SDK
+- default to 4.13; update docs w/ latest version numbers
+- add support for "next" version of
 
 ## [2.10.2] - 2019-10-12
 
@@ -95,7 +95,7 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [2.10.0] - 2019-07-03
 ### Added
-- default to JS SDK 4.12; update docs w/ latest version numbers
+- default to 4.12; update docs w/ latest version numbers
 
 ## [2.9.2] - 2019-04-18
 
@@ -109,7 +109,7 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [2.9.0] - 2019-03-29
 ### Added
-- default to JS SDK 4.11; update docs w/ latest version numbers
+- default to 4.11; update docs w/ latest version numbers
 
 ## [2.8.0] - 2019-03-27
 ### Added
@@ -129,21 +129,21 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 ## [2.6.0] - 2018-12-17
 
 ### Added
-- default to JS SDK 4.10; update docs w/ latest version numbers
+- default to 4.10; update docs w/ latest version numbers
 
 ## [2.5.0] - 2018-09-29
 
 ### Changed
-- default to JS SDK 4.9; update docs w/ latest version numbers
+- default to 4.9; update docs w/ latest version numbers
 
 ## [2.4.0]
 
 ### Changed
-- default to JS SDK 4.8; update docs w/ latest version numbers
+- default to 4.8; update docs w/ latest version numbers
 
 ## [2.3.0]
 ### Added
-- default to JS SDK 4.7; update docs w/ latest version numbers
+- default to 4.7; update docs w/ latest version numbers
 ### Changed
 - added Hyperapp example link to README
 - move CSS functions into own module
@@ -197,7 +197,7 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [1.6.0] - 2017-12-31
 ### Added
-- default to version 4.6 of the JS SDK [#63](https://github.com/Esri/esri-loader/issues/63)
+- default to version 4.6 [#63](https://github.com/Esri/esri-loader/issues/63)
 ### Changed
 - remove remaining references to angular-esri-loader from README
 - update README w/ info on arcgis types and browser support [#60](https://github.com/Esri/esri-loader/issues/60)
@@ -251,7 +251,7 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 ## [1.2.0]
 
 ### Added
-- default to version 4.5 of the JS SDK
+- default to 4.5
 
 ### Fixed
 - don't throw an error when `bootstrap()` is called multiple times w/o a callback
@@ -262,7 +262,7 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 ## [1.1.0]
 
 ### Added
-- default to version 4.4 of the JS SDK
+- default to 4.4
 
 ## [1.0.0]
 
@@ -289,13 +289,13 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 ## [0.2.0]
 
 ### Added
-- enable pre-loading the JS SDK
-- default to version 4.3 of the JS SDK
+- enable pre-loading
+- default to 4.3
 
 ## [0.1.3]
 
 ### Fixed
-- default to version 4.2 of the JS SDK
+- default to 4.2
 - use HTTPS by default
 
 ## [0.1.2]

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -37,7 +37,7 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [3.2.0] - 2021-07-07
 ### Added
-- default to JS SDK 4.20; update docs w/ latest version numbers - @gavinr
+- default to 4.20; update docs w/ latest version numbers - @gavinr
 
 ## [3.1.0] - 2021-04-23
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,14 +11,14 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [3.7.0] - 2022-11-16
 ### Added
-- default to JS API 4.25; update docs w/ latest version numbers - @andygup
+- default to JS SDK 4.25; update docs w/ latest version numbers - @andygup
 ### Changed
 - raise visibility of deprecation notice for frameworks that do not support async/await at runtime, e.g. Angular due to limitations in Zone.js
 - archive framework samples and various 3.x-related sections to archived-examples.md. Most of the samples haven't been updated in years
 
 ## [3.6.0] - 2022-07-07
 ### Added
-- default to JSAPI 4.24; update docs w/ latest version numbers - @gavinr
+- default to JS SDK 4.24; update docs w/ latest version numbers - @gavinr
 
 ### Changed
 - fix build by not compiling @types
@@ -27,47 +27,47 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [3.5.0] - 2022-03-29
 ### Added
-- default to JSAPI 4.23; update docs w/ latest version numbers - @gavinr
+- default to JS SDK 4.23; update docs w/ latest version numbers - @gavinr
 
 ## [3.4.0] - 2022-01-14
 ### Added
-- default to JSAPI 4.22; update docs w/ latest version numbers - @gavinr
+- default to JS SDK 4.22; update docs w/ latest version numbers - @gavinr
 
 ## [3.3.0] - 2021-09-22
 
 ## [3.2.0] - 2021-07-07
 ### Added
-- default to JSAPI 4.20; update docs w/ latest version numbers - @gavinr
+- default to JS SDK 4.20; update docs w/ latest version numbers - @gavinr
 
 ## [3.1.0] - 2021-04-23
 ### Added
-- default to JSAPI 4.19; update docs w/ latest version numbers - @vannizhang
+- default to JS SDK 4.19; update docs w/ latest version numbers - @vannizhang
 
 ## [3.0.0] - 2020-12-31
 ### Added
-- default to JSAPI 4.18; update docs w/ latest version numbers - @gavinr
+- default to JS SDK 4.18; update docs w/ latest version numbers - @gavinr
 
 ### Breaking
-- default version of JSAPI no longer supports IE
+- default version of JS SDK no longer supports IE
 - remove option to set `dojoConfig`
 - remove esri-loader default export
 
 ## [2.16.0] - 2020-10-13
 ### Added
-- default to JSAPI 4.17; update docs w/ latest version numbers - @tgirgin23
+- default to JS SDK 4.17; update docs w/ latest version numbers - @tgirgin23
 
 ## [2.15.0] - 2020-07-10
 ### Added
-- default to JSAPI 4.16; update docs w/ latest version numbers - @JoshCrozier
+- default to JS SDK 4.16; update docs w/ latest version numbers - @JoshCrozier
 
 ## [2.14.0] - 2020-04-09
 ### Added
-- default to JSAPI 4.15; update docs w/ latest version numbers - @JoshCrozier
+- default to JS SDK 4.15; update docs w/ latest version numbers - @JoshCrozier
 
 ## [2.13.0] - 2019-12-22
 
 ### Added
-- default to JSAPI 4.14; update docs w/ latest version numbers - @gpbmike
+- default to JS SDK 4.14; update docs w/ latest version numbers - @gpbmike
 
 ## [2.12.0] - 2019-10-24
 
@@ -78,8 +78,8 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [2.11.0] - 2019-10-14
 ### Added
-- default to JSAPI 4.13; update docs w/ latest version numbers
-- add support for "next" version of ArcGIS API
+- default to JS SDK 4.13; update docs w/ latest version numbers
+- add support for "next" version of JS SDK
 
 ## [2.10.2] - 2019-10-12
 
@@ -95,7 +95,7 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [2.10.0] - 2019-07-03
 ### Added
-- default to JSAPI 4.12; update docs w/ latest version numbers
+- default to JS SDK 4.12; update docs w/ latest version numbers
 
 ## [2.9.2] - 2019-04-18
 
@@ -109,7 +109,7 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [2.9.0] - 2019-03-29
 ### Added
-- default to JSAPI 4.11; update docs w/ latest version numbers
+- default to JS SDK 4.11; update docs w/ latest version numbers
 
 ## [2.8.0] - 2019-03-27
 ### Added
@@ -129,21 +129,21 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 ## [2.6.0] - 2018-12-17
 
 ### Added
-- default to JSAPI 4.10; update docs w/ latest version numbers
+- default to JS SDK 4.10; update docs w/ latest version numbers
 
 ## [2.5.0] - 2018-09-29
 
 ### Changed
-- default to JSAPI 4.9; update docs w/ latest version numbers
+- default to JS SDK 4.9; update docs w/ latest version numbers
 
 ## [2.4.0]
 
 ### Changed
-- default to JSAPI 4.8; update docs w/ latest version numbers
+- default to JS SDK 4.8; update docs w/ latest version numbers
 
 ## [2.3.0]
 ### Added
-- default to JSAPI 4.7; update docs w/ latest version numbers
+- default to JS SDK 4.7; update docs w/ latest version numbers
 ### Changed
 - added Hyperapp example link to README
 - move CSS functions into own module
@@ -197,7 +197,7 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [1.6.0] - 2017-12-31
 ### Added
-- default to version 4.6 of the ArcGIS API [#63](https://github.com/Esri/esri-loader/issues/63)
+- default to version 4.6 of the JS SDK [#63](https://github.com/Esri/esri-loader/issues/63)
 ### Changed
 - remove remaining references to angular-esri-loader from README
 - update README w/ info on arcgis types and browser support [#60](https://github.com/Esri/esri-loader/issues/60)
@@ -251,7 +251,7 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 ## [1.2.0]
 
 ### Added
-- default to version 4.5 of the ArcGIS API
+- default to version 4.5 of the JS SDK
 
 ### Fixed
 - don't throw an error when `bootstrap()` is called multiple times w/o a callback
@@ -262,7 +262,7 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 ## [1.1.0]
 
 ### Added
-- default to version 4.4 of the ArcGIS API
+- default to version 4.4 of the JS SDK
 
 ## [1.0.0]
 
@@ -289,13 +289,13 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 ## [0.2.0]
 
 ### Added
-- enable pre-loading the ArcGIS API
-- default to version 4.3 of the ArcGIS API
+- enable pre-loading the JS SDK
+- default to version 4.3 of the JS SDK
 
 ## [0.1.3]
 
 ### Fixed
-- default to version 4.2 of the ArcGIS API
+- default to version 4.2 of the JS SDK
 - use HTTPS by default
 
 ## [0.1.2]

--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ A tiny library to help you use the [ArcGIS Maps SDK for JavaScript](https://deve
 
 Ready to jump in? Follow the [Install](#install) and [Usage](#usage) instructions below to get started. Then see more in depth instructions on how to [configure esri-loader](#configuring-esri-loader).
 
-Want to learn more? Learn how esri-loader can help [improve application load performance](#lazy-loading-the-arcgis-api-for-javascript) and allow you to [use the API in server side rendered applications](#server-side-rendering).
+Want to learn more? Learn how esri-loader can help [improve application load performance](#lazy-loading-the-arcgis-api-for-javascript) and allow you to [use the Maps SDK in server side rendered applications](#server-side-rendering).
 
 Looking for legacy examples from a variety of frameworks, or 3.x information? Visit the [archive](archived-examples.md) page.
 
@@ -154,13 +154,13 @@ See [Configuring esri-loader](#configuring-esri-loader) for all available config
 
 ### Lazy Loading
 
-Lazy loading the API can dramatically improve the initial load performance of your mapping application, especially if your users may never end up visiting any routes that need to show a map or 3D scene. That is why it is the default behavior of esri-loader. In the above snippets, the first time `loadModules()` is called, it will lazy load the API by injecting a `<script>` tag in the page. That call and any subsequent calls to `loadModules()` will wait for the script to load before resolving with the modules.
+Lazy loading the modules can dramatically improve the initial load performance of your mapping application, especially if your users may never end up visiting any routes that need to show a map or 3D scene. That is why it is the default behavior of esri-loader. In the above snippets, the first time `loadModules()` is called, it will lazy load the modules by injecting a `<script>` tag in the page. That call and any subsequent calls to `loadModules()` will wait for the script to load before resolving with the modules.
 
-If you have some reason why you do not want to lazy load the API, you can [use a static script tag](#using-your-own-script-tag) instead.
+If you have some reason why you do not want to lazy load the modules, you can [use a static script tag](#using-your-own-script-tag) instead.
 
 ### Loading Styles
 
-Before you can use the API in your app, you _must_ load the styles that correspond to the version you are using. Just like the APIs modules, you'll probably want to [lazy load](#lazy-loading-the-arcgis-api-for-javascript) the styles only once they are needed by the application.
+You _must_ load the styles that correspond to the version you are using. You'll probably want to [lazy load](#lazy-loading-the-arcgis-api-for-javascript) the styles only once they are needed by the application.
 
 #### When you load the script
 
@@ -211,10 +211,10 @@ It is recommended to try installing [@arcgis/core](https://www.npmjs.com/package
 
 <a id="why-is-this-needed"></a>For versions of the SDK before 4.18, esri-loader is required when working with frameworks or bundlers. esri-loader provides a way to dynamically load the SDK's AMD modules at runtime from the [ArcGIS CDN](https://developers.arcgis.com/javascript/latest/install-and-set-up/#amd-modules-via-arcgis-cdn) into applications built using modern tools and framework conventions. This allows your application to take advantage of the fast cached [CDN](https://developers.arcgis.com/javascript/latest/guide/get-api/#cdn).
 
-esri-loader provides a convenient way to lazy load the API in any application, and it has been the most versatile way to integrate the ArcGIS Maps SDK for JavaScript with other frameworks and their tools since it works in applications that:
+esri-loader provides a convenient way to lazy load the modules in any application, and it has been the most versatile way to integrate the ArcGIS Maps SDK for JavaScript with other frameworks and their tools since it works in applications that:
 - are built with _any_ loader/bundler, such as [webpack](https://webpack.js.org/), [rollup.js](https://rollupjs.org/), or [Parcel](https://parceljs.org)
 - use framework tools that discourage or prevent you from manually editing their configuration
-- make very limited use of the API and don't want to incur the cost of including it in their build
+- make very limited use of the Maps SDK and don't want to incur the cost of including it in their build
 
 Most developers will prefer the convenience and native interoperability of being able to `import` modules from `@arcgis/core` directly, especially if their application makes extensive use of the SDK. However, if `@arcgis/core` doesn't work in your application for whatever reason, esri-loader probably will.
 

--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ A tiny library to help you use the [ArcGIS Maps SDK for JavaScript](https://deve
 
 Ready to jump in? Follow the [Install](#install) and [Usage](#usage) instructions below to get started. Then see more in depth instructions on how to [configure esri-loader](#configuring-esri-loader).
 
-Want to learn more? Learn how esri-loader can help [improve application load performance](#lazy-loading-the-arcgis-api-for-javascript) and allow you to [use the ArcGIS SDK in server side rendered applications](#server-side-rendering).
+Want to learn more? Learn how esri-loader can help [improve application load performance](#lazy-loading-the-arcgis-api-for-javascript) and allow you to [use the API in server side rendered applications](#server-side-rendering).
 
 Looking for legacy examples from a variety of frameworks, or 3.x information? Visit the [archive](archived-examples.md) page.
 
@@ -152,15 +152,15 @@ setDefaultOptions({ url: `http://server/path/to/esri` });
 
 See [Configuring esri-loader](#configuring-esri-loader) for all available configuration options.
 
-### Lazy Loading the ArcGIS Maps SDK for JavaScript
+### Lazy Loading
 
-Lazy loading the SDK can dramatically improve the initial load performance of your mapping application, especially if your users may never end up visiting any routes that need to show a map or 3D scene. That is why it is the default behavior of esri-loader. In the above snippets, the first time `loadModules()` is called, it will lazy load the SDK by injecting a `<script>` tag in the page. That call and any subsequent calls to `loadModules()` will wait for the script to load before resolving with the modules.
+Lazy loading the API can dramatically improve the initial load performance of your mapping application, especially if your users may never end up visiting any routes that need to show a map or 3D scene. That is why it is the default behavior of esri-loader. In the above snippets, the first time `loadModules()` is called, it will lazy load the API by injecting a `<script>` tag in the page. That call and any subsequent calls to `loadModules()` will wait for the script to load before resolving with the modules.
 
-If you have some reason why you do not want to lazy load the SDK, you can [use a static script tag](#using-your-own-script-tag) instead.
+If you have some reason why you do not want to lazy load the API, you can [use a static script tag](#using-your-own-script-tag) instead.
 
 ### Loading Styles
 
-Before you can use the SDK in your app, you _must_ load the styles that correspond to the version you are using. Just like the SDK modules, you'll probably want to [lazy load](#lazy-loading-the-arcgis-api-for-javascript) the styles only once they are needed by the application.
+Before you can use the API in your app, you _must_ load the styles that correspond to the version you are using. Just like the APIs modules, you'll probably want to [lazy load](#lazy-loading-the-arcgis-api-for-javascript) the styles only once they are needed by the application.
 
 #### When you load the script
 
@@ -211,10 +211,10 @@ It is recommended to try installing [@arcgis/core](https://www.npmjs.com/package
 
 <a id="why-is-this-needed"></a>For versions of the SDK before 4.18, esri-loader is required when working with frameworks or bundlers. esri-loader provides a way to dynamically load the SDK's AMD modules at runtime from the [ArcGIS CDN](https://developers.arcgis.com/javascript/latest/install-and-set-up/#amd-modules-via-arcgis-cdn) into applications built using modern tools and framework conventions. This allows your application to take advantage of the fast cached [CDN](https://developers.arcgis.com/javascript/latest/guide/get-api/#cdn).
 
-esri-loader provides a convenient way to lazy load the SDK in any application, and it has been the most versatile way to integrate the ArcGIS Maps SDK for JavaScript with other frameworks and their tools since it works in applications that:
+esri-loader provides a convenient way to lazy load the API in any application, and it has been the most versatile way to integrate the ArcGIS Maps SDK for JavaScript with other frameworks and their tools since it works in applications that:
 - are built with _any_ loader/bundler, such as [webpack](https://webpack.js.org/), [rollup.js](https://rollupjs.org/), or [Parcel](https://parceljs.org)
 - use framework tools that discourage or prevent you from manually editing their configuration
-- make very limited use of the SDK and don't want to incur the cost of including it in their build
+- make very limited use of the API and don't want to incur the cost of including it in their build
 
 Most developers will prefer the convenience and native interoperability of being able to `import` modules from `@arcgis/core` directly, especially if their application makes extensive use of the SDK. However, if `@arcgis/core` doesn't work in your application for whatever reason, esri-loader probably will.
 

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 [![Travis](https://img.shields.io/travis/Esri/esri-loader.svg)](https://travis-ci.org/Esri/esri-loader/builds/) [![npm](https://img.shields.io/npm/v/esri-loader.svg)](https://github.com/Esri/esri-loader/releases) [![npm](https://img.shields.io/npm/dw/esri-loader.svg)](https://www.npmjs.com/package/esri-loader) [![npm](https://img.shields.io/npm/l/esri-loader.svg)](https://github.com/Esri/esri-loader/blob/master/LICENSE) [![GitHub stars](https://img.shields.io/github/stars/esri/esri-loader.svg?style=social&label=Stars)](https://github.com/Esri/esri-loader/stargazers)
 
-A tiny library to help you use the [ArcGIS API for JavaScript](https://developers.arcgis.com/javascript/latest/tooling-intro/) AMD modules in applications built with popular JavaScript frameworks and bundlers.
+A tiny library to help you use the [ArcGIS Maps SDK for JavaScript](https://developers.arcgis.com/javascript/latest/tooling-intro/) AMD modules in applications built with popular JavaScript frameworks and bundlers.
 
 **NOTE: It is recommended to try installing [@arcgis/core](https://www.npmjs.com/package/@arcgis/core) and [building with ES Modules](https://developers.arcgis.com/javascript/latest/guide/es-modules) _instead_ of using esri-loader.** Read more below about [when you might want to use esri-loader](#why-is-this-needed).
 
@@ -10,7 +10,7 @@ A tiny library to help you use the [ArcGIS API for JavaScript](https://developer
 
 Ready to jump in? Follow the [Install](#install) and [Usage](#usage) instructions below to get started. Then see more in depth instructions on how to [configure esri-loader](#configuring-esri-loader).
 
-Want to learn more? Learn how esri-loader can help [improve application load performance](#lazy-loading-the-arcgis-api-for-javascript) and allow you to [use the ArcGIS API in server side rendered applications](#server-side-rendering).
+Want to learn more? Learn how esri-loader can help [improve application load performance](#lazy-loading-the-arcgis-api-for-javascript) and allow you to [use the ArcGIS SDK in server side rendered applications](#server-side-rendering).
 
 Looking for legacy examples from a variety of frameworks, or 3.x information? Visit the [archive](archived-examples.md) page.
 
@@ -19,8 +19,8 @@ Looking for legacy examples from a variety of frameworks, or 3.x information? Vi
 - [Known Limitations](#known-limitations)
 - [Install](#install)
 - [Usage](#usage)
-  - [Loading Modules from the ArcGIS API for JavaScript](#loading-modules-from-the-arcgis-api-for-javascript)
-  - [Lazy Loading the ArcGIS API for JavaScript](#lazy-loading-the-arcgis-api-for-javascript)
+  - [Loading Modules from the ArcGIS Maps SDK for JavaScript](#loading-modules-from-the-arcgis-api-for-javascript)
+  - [Lazy Loading the ArcGIS Maps SDK for JavaScript](#lazy-loading-the-arcgis-api-for-javascript)
   - [Loading Styles](#loading-styles)
 - [Do I need esri-loader?](#do-i-need-esri-loader)
 - [Advanced Usage](#advanced-usage)
@@ -29,7 +29,7 @@ Looking for legacy examples from a variety of frameworks, or 3.x information? Vi
   - [Configuring esri-loader](#configuring-esri-loader)
   - [Configuring Dojo](#configuring-dojo)
   - [Overriding ArcGIS Styles](#overriding-arcgis-styles)
-  - [Pre-loading the ArcGIS API for JavaScript](#pre-loading-the-arcgis-api-for-javascript)
+  - [Pre-loading the ArcGIS Maps SDK for JavaScript](#pre-loading-the-arcgis-api-for-javascript)
   - [Using your own script tag](#using-your-own-script-tag)
   - [Without a module bundler](#without-a-module-bundler)
     - [Using a module script tag](#using-a-module-script-tag)
@@ -50,7 +50,7 @@ Looking for legacy examples from a variety of frameworks, or 3.x information? Vi
 
 ## Known Limitations
 
-- <a id="known-limitations"></a>Compatibility with implementations that don't support [async/await](https://developer.mozilla.org/en-US/docs/Learn/JavaScript/Asynchronous/Promises#async_and_await) at runtime, within AMD modules, is deprecated at version 4.25 (November 2022) - this means the functionality will be removed in a future release. In particular, this affects Angular applications using esri-loader because of [well-known limitations in Zone.js](https://angular.io/guide/roadmap#improve-runtime-performance-and-make-zonejs-optional). Angular users will need to migrate from AMD modules to using [@arcgis/core ES modules](https://developers.arcgis.com/javascript/latest/es-modules/) in order to continue using the latest release of the API. Refer to the [APIs FAQ](https://developers.arcgis.com/javascript/latest/faq/#how-are-breaking-changes-managed) for more information on breaking changes.
+- <a id="known-limitations"></a>Compatibility with implementations that don't support [async/await](https://developer.mozilla.org/en-US/docs/Learn/JavaScript/Asynchronous/Promises#async_and_await) at runtime, within AMD modules, is deprecated at version 4.25 (November 2022) - this means the functionality will be removed in a future release. In particular, this affects Angular applications using esri-loader because of [well-known limitations in Zone.js](https://angular.io/guide/roadmap#improve-runtime-performance-and-make-zonejs-optional). Angular users will need to migrate from AMD modules to using [@arcgis/core ES modules](https://developers.arcgis.com/javascript/latest/es-modules/) in order to continue using the latest release of the SDK. Refer to the [FAQ](https://developers.arcgis.com/javascript/latest/faq/#how-are-breaking-changes-managed) for more information on breaking changes.
 
 ## Install
 
@@ -66,9 +66,9 @@ yarn add esri-loader
 
 ## Usage
 
-The code snippets below show how to load the ArcGIS API and its modules and then use them to create a map. Where you would place similar code in your application will depend on which application framework you are using. 
+The code snippets below show how to load the ArcGIS Maps SDK for JavaScript and its modules and then use them to create a map. Where you would place similar code in your application will depend on which application framework you are using. 
 
-### Loading Modules from the ArcGIS API for JavaScript
+### Loading Modules from the ArcGIS Maps SDK for JavaScript
 
 #### From the Latest Version
 
@@ -77,7 +77,7 @@ Here's an example of how you could load and use the `WebMap` and `MapView` class
 ```js
 import { loadModules } from 'esri-loader';
 
-// this will lazy load the ArcGIS API
+// this will lazy load the SDK
 // and then use Dojo's loader to require the classes
 loadModules(['esri/views/MapView', 'esri/WebMap'])
   .then(([MapView, WebMap]) => {
@@ -101,7 +101,7 @@ loadModules(['esri/views/MapView', 'esri/WebMap'])
 
 #### From a Specific Version
 
-By default esri-loader will load modules from the [latest 4.x release of the API from the CDN](https://developers.arcgis.com/javascript/latest/guide/get-api/#cdn), but you can [configure the default behavior](#configuring-esri-loader) by calling `setDefaultOptions()` once _before_ making any calls to `loadModules()`.
+By default esri-loader will load modules from the [latest 4.x release of the SDK from the CDN](https://developers.arcgis.com/javascript/latest/guide/get-api/#cdn), but you can [configure the default behavior](#configuring-esri-loader) by calling `setDefaultOptions()` once _before_ making any calls to `loadModules()`.
 
 ```js
 // app.js
@@ -118,7 +118,7 @@ Then later, for example after a map component has mounted, you would use `loadMo
 // component.js
 import { loadModules } from 'esri-loader';
 
-// this will lazy load the ArcGIS API
+// this will lazy load the SDK
 // and then use Dojo's loader to require the map class
 loadModules(['esri/map'])
   .then(([Map]) => {
@@ -135,7 +135,7 @@ loadModules(['esri/map'])
   });
 ```
 
-You can load the ["next" version of the ArcGIS API](https://github.com/Esri/feedback-js-api-next#esri-loader) by passing `version: 'next'`.
+You can load the ["next" version of the SDK](https://github.com/Esri/feedback-js-api-next#esri-loader) by passing `version: 'next'`.
 
 #### From a Specific URL
 
@@ -145,22 +145,22 @@ If you want to load modules from a build that you host on your own server (i.e. 
 // app.js
 import { setDefaultOptions } from 'esri-loader';
 
-// configure esri-loader to use version from a locally hosted build of the API
+// configure esri-loader to use version from a locally hosted build of the SDK
 // NOTE: make sure this is called once before any calls to loadModules()
 setDefaultOptions({ url: `http://server/path/to/esri` });
 ```
 
 See [Configuring esri-loader](#configuring-esri-loader) for all available configuration options.
 
-### Lazy Loading the ArcGIS API for JavaScript
+### Lazy Loading the ArcGIS Maps SDK for JavaScript
 
-Lazy loading the ArcGIS API can dramatically improve the initial load performance of your mapping application, especially if your users may never end up visiting any routes that need to show a map or 3D scene. That is why it is the default behavior of esri-loader. In the above snippets, the first time `loadModules()` is called, it will lazy load the ArcGIS API by injecting a `<script>` tag in the page. That call and any subsequent calls to `loadModules()` will wait for the script to load before resolving with the modules.
+Lazy loading the SDK can dramatically improve the initial load performance of your mapping application, especially if your users may never end up visiting any routes that need to show a map or 3D scene. That is why it is the default behavior of esri-loader. In the above snippets, the first time `loadModules()` is called, it will lazy load the SDK by injecting a `<script>` tag in the page. That call and any subsequent calls to `loadModules()` will wait for the script to load before resolving with the modules.
 
-If you have some reason why you do not want to lazy load the ArcGIS API, you can [use a static script tag](#using-your-own-script-tag) instead.
+If you have some reason why you do not want to lazy load the SDK, you can [use a static script tag](#using-your-own-script-tag) instead.
 
 ### Loading Styles
 
-Before you can use the ArcGIS API in your app, you _must_ load the styles that correspond to the version you are using. Just like the ArcGIS API modules, you'll probably want to [lazy load](#lazy-loading-the-arcgis-api-for-javascript) the styles only once they are needed by the application.
+Before you can use the SDK in your app, you _must_ load the styles that correspond to the version you are using. Just like the SDK modules, you'll probably want to [lazy load](#lazy-loading-the-arcgis-api-for-javascript) the styles only once they are needed by the application.
 
 #### When you load the script
 
@@ -203,20 +203,20 @@ See below for information on how to [override ArcGIS styles](#overriding-arcgis-
 
 #### Using traditional means
 
-Of course, you don't need to use esri-loader to load the styles. See the [ArcGIS API for JavaScript documentation](https://developers.arcgis.com/javascript/latest/guide/get-api/index.html) for more information on how to load the ArcGIS styles by more traditional means such as adding `<link>` tags to your HTML, or `@import` statements to your CSS.
+Of course, you don't need to use esri-loader to load the styles. See the [ArcGIS Maps SDK for JavaScript documentation](https://developers.arcgis.com/javascript/latest/guide/get-api/index.html) for more information on how to load the ArcGIS styles by more traditional means such as adding `<link>` tags to your HTML, or `@import` statements to your CSS.
 
 ## Do I need esri-loader?
 
 It is recommended to try installing [@arcgis/core](https://www.npmjs.com/package/@arcgis/core) and [building with ES Modules](https://developers.arcgis.com/javascript/latest/guide/es-modules) and _instead_ of using esri-loader. It's also pretty easy to [migrate applications built  with esri-loader](https://developers.arcgis.com/javascript/latest/guide/es-modules/#esri-loader).
 
-<a id="why-is-this-needed"></a>For versions of the API before 4.18, esri-loader is required when working with frameworks or bundlers. esri-loader provides a way to dynamically load the API's AMD modules at runtime from the [ArcGIS CDN](https://developers.arcgis.com/javascript/latest/install-and-set-up/#amd-modules-via-arcgis-cdn) into applications built using modern tools and framework conventions. This allows your application to take advantage of the fast cached [CDN](https://developers.arcgis.com/javascript/latest/guide/get-api/#cdn).
+<a id="why-is-this-needed"></a>For versions of the SDK before 4.18, esri-loader is required when working with frameworks or bundlers. esri-loader provides a way to dynamically load the SDK's AMD modules at runtime from the [ArcGIS CDN](https://developers.arcgis.com/javascript/latest/install-and-set-up/#amd-modules-via-arcgis-cdn) into applications built using modern tools and framework conventions. This allows your application to take advantage of the fast cached [CDN](https://developers.arcgis.com/javascript/latest/guide/get-api/#cdn).
 
-esri-loader provides a convenient way to lazy load the API in any application, and it has been the most versatile way to integrate the ArcGIS API for JavaScript with other frameworks and their tools since it works in applications that:
+esri-loader provides a convenient way to lazy load the SDK in any application, and it has been the most versatile way to integrate the ArcGIS Maps SDK for JavaScript with other frameworks and their tools since it works in applications that:
 - are built with _any_ loader/bundler, such as [webpack](https://webpack.js.org/), [rollup.js](https://rollupjs.org/), or [Parcel](https://parceljs.org)
 - use framework tools that discourage or prevent you from manually editing their configuration
-- make very limited use of the ArcGIS API and don't want to incur the cost of including it in their build
+- make very limited use of the SDK and don't want to incur the cost of including it in their build
 
-Most developers will prefer the convenience and native interoperability of being able to `import` modules from `@arcgis/core` directly, especially if their application makes extensive use of the ArcGIS API. However, if `@arcgis/core` doesn't work in your application for whatever reason, esri-loader probably will.
+Most developers will prefer the convenience and native interoperability of being able to `import` modules from `@arcgis/core` directly, especially if their application makes extensive use of the SDK. However, if `@arcgis/core` doesn't work in your application for whatever reason, esri-loader probably will.
 
 Learn more about [which is the right solution for your application](https://developers.arcgis.com/javascript/latest/guide/tooling-intro/).
 
@@ -224,7 +224,7 @@ Learn more about [which is the right solution for your application](https://deve
 
 ### ArcGIS TypeScript Types
 
-This library doesn't make any assumptions about which version of the ArcGIS API for JavaScript you are using, so you will have to install the appropriate types. Furthermore, because you don't `import` esri modules directly with esri-loader, you'll have to follow the instructions below to use the types in your application.
+This library doesn't make any assumptions about which version of the ArcGIS Maps SDK JavaScript you are using, so you will have to install the appropriate types. Furthermore, because you don't `import` esri modules directly with esri-loader, you'll have to follow the instructions below to use the types in your application.
 
 Follow [these instructions](https://github.com/Esri/jsapi-resources/tree/master/4.x/typescript) to install the 4.x types.
 
@@ -251,7 +251,7 @@ For Angular CLI applications, you will also need to add "arcgis-js-api" to `comp
 
 #### esri-loader-typings-helper Plugin
 
-An easy way to automatically get the typings for the ArcGIS JS API modules is to use the [esri-loader-typings-helper](https://marketplace.visualstudio.com/items?itemName=CalebMackey.esri-loader-typings-helper) plugin for [VS Code](https://code.visualstudio.com/).  This plugin will allow you to simply call out an array of modules to import, and when the text is selected and the plugin is called, it will automatically generate the `loadModules()` code for you in either the `async/await` pattern or using a `Promise`:
+An easy way to automatically get the typings for the SDK modules is to use the [esri-loader-typings-helper](https://marketplace.visualstudio.com/items?itemName=CalebMackey.esri-loader-typings-helper) plugin for [VS Code](https://code.visualstudio.com/).  This plugin will allow you to simply call out an array of modules to import, and when the text is selected and the plugin is called, it will automatically generate the `loadModules()` code for you in either the `async/await` pattern or using a `Promise`:
 
 async example:
 
@@ -265,12 +265,12 @@ promise example:
 
 ### Configuring esri-loader
 
-As mentioned above, you can call `setDefaultOptions()` to configure [how esri-loader loads ArcGIS API modules](#from-a-specific-version) and [CSS](#when-you-load-the-script). Here are all the options you can set:
+As mentioned above, you can call `setDefaultOptions()` to configure [how esri-loader loads ArcGIS Maps SDK for JavaScript modules](#from-a-specific-version) and [CSS](#when-you-load-the-script). Here are all the options you can set:
 
 | Name              | Type                  | Default Value | Description                                                                                                                                                                                                                                             |
 | ----------------- | --------------------- | ------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `version`         | `string`              | `'4.25'`      | The version of the ArcGIS API hosted on Esri's CDN to use.                                                                                                                                                                                              |
-| `url`             | `string`              | `undefined`   | The URL to a hosted build of the ArcGIS API to use. If both `version` and `url` are passed, `url` will be used.                                                                                                                                         |
+| `version`         | `string`              | `'4.25'`      | The version of the SDK hosted on Esri's CDN to use.                                                                                                                                                                                              |
+| `url`             | `string`              | `undefined`   | The URL to a hosted build of the SDK to use. If both `version` and `url` are passed, `url` will be used.                                                                                                                                         |
 | `css`             | `string` or `boolean` | `undefined`   | If a `string` is passed it is assumed to be the URL of a CSS file to load. Use `css: true` to load the `version`'s CSS from the CDN.                                                                                                                    |
 | `insertCssBefore` | `string`              | `undefined`   | When using `css`, the `<link>` to the stylesheet will be inserted before the first element that matches this [CSS Selector](https://developer.mozilla.org/en-US/docs/Web/CSS/CSS_Selectors). See [Overriding ArcGIS Styles](#overriding-arcgis-styles). |
 
@@ -304,12 +304,12 @@ loadModules(['esri/map'], options)
 
 ### Configuring Dojo
 
-You can set `window.dojoConfig` before calling `loadModules()` to [configure Dojo](https://dojotoolkit.org/documentation/tutorials/1.10/dojo_config/) before the script tag is loaded. This is useful if you want to use esri-loader to load Dojo packages that are not included in the ArcGIS API for JavaScript such as [FlareClusterLayer](https://github.com/nickcam/FlareClusterLayer).
+You can set `window.dojoConfig` before calling `loadModules()` to [configure Dojo](https://dojotoolkit.org/documentation/tutorials/1.10/dojo_config/) before the script tag is loaded. This is useful if you want to use esri-loader to load Dojo packages that are not included in the ArcGIS Maps SDK for JavaScript such as [FlareClusterLayer](https://github.com/nickcam/FlareClusterLayer).
 
 ```js
 import { loadModules } from 'esri-loader';
 
-// can configure Dojo before loading the API
+// can configure Dojo before loading the SDK
 window.dojoConfig = {
   // tell Dojo where to load other packages
   async: true,
@@ -352,18 +352,18 @@ loadModules(['esri/views/MapView', 'esri/WebMap'], options);
 
 Alternatively you could insert it before the first `<link>` tag w/ `insertCssBefore: 'link[rel="stylesheet"]'`,  etc.
 
-### Pre-loading the ArcGIS API for JavaScript
+### Pre-loading the ArcGIS Maps SDK JavaScript
 
-Under the hood, `loadModules()` calls esri-loader's `loadScript()` function to lazy load the ArcGIS API by injecting a `<script>` tag into the page.
+Under the hood, `loadModules()` calls esri-loader's `loadScript()` function to lazy load the SDK by injecting a `<script>` tag into the page.
 
-If `loadModules()` hasn't yet been called, but you have good reason to believe that the user is going take an action that will call it (i.e. transition to a route that shows a map), you can call `loadScript()` ahead of time to start loading ArcGIS API. For example:
+If `loadModules()` hasn't yet been called, but you have good reason to believe that the user is going take an action that will call it (i.e. transition to a route that shows a map), you can call `loadScript()` ahead of time to start loading SDK. For example:
 
 ```js
 import { loadScript, loadModules } from 'esri-loader';
 
-// preload the ArcGIS API
+// preload the SDK
 // NOTE: in this case, we're not passing any options to loadScript()
-// so it will default to loading the latest 4.x version of the API from the CDN
+// so it will default to loading the latest 4.x version of the SDK from the CDN
 loadScript();
 
 // later, for example after transitioning to a route with a map
@@ -376,7 +376,7 @@ See [Configuring esri-loader](#configuring-esri-loader) for all available config
 
 ### Using your own script tag
 
-It is possible to use this library only to load modules (i.e. not to lazy load or pre-load the ArcGIS API). In this case you will need to add a `data-esri-loader` attribute to the script tag you use to load the ArcGIS API for JavaScript. Example:
+It is possible to use this library only to load modules (i.e. not to lazy load or pre-load the ArcGIS Maps SDK for JavaScript). In this case you will need to add a `data-esri-loader` attribute to the script tag you use to load the SDK. Example:
 
 ```html
 <!-- index.html -->
@@ -387,7 +387,7 @@ It is possible to use this library only to load modules (i.e. not to lazy load o
 
 Typically you would [install the esri-loader package](#install) and then use a module loader/bundler to `import` the functions you need as part of your application's build. However, ES5 builds of esri-loader are also distributed on [UNPKG](https://unpkg.com/) both as ES modules and as a [UMD](http://jargon.js.org/_glossary/UMD.md) bundle that exposes the `esriLoader` global.
 
-This is an _excellent_ way to prototype how you will use the ArcGIS API for JavaScript, or to isolate any problems that you are having with the API. Before we can help you with any issue related to the behavior of a map, scene, or widgets, we will **require** you to reproduce it _outside_ your application. A great place to start is one of the codepens linked below.
+This is an _excellent_ way to prototype how you will use the ArcGIS Maps SDK for JavaScript, or to isolate any problems that you are having with the SDK. Before we can help you with any issue related to the behavior of a map, scene, or widgets, we will **require** you to reproduce it _outside_ your application. A great place to start is one of the codepens linked below.
 
 #### Using a module script tag
 
@@ -476,7 +476,7 @@ See [#124 (comment)](https://github.com/Esri/esri-loader/issues/124#issuecomment
 
 ### Server Side Rendering
 
-<a id="isomorphicuniversal-applications"></a>This library also allows you to use the ArcGIS API in [applications that are rendered on the server](https://medium.com/@baphemot/whats-server-side-rendering-and-do-i-need-it-cb42dc059b38). There's really no difference in how you invoke the functions exposed by this library, however you should avoid trying to call them from any code that runs on the server. The easiest way to do this is to call `loadModules()` in component lifecyle hooks that are only invoked in a browser, for example, React's [useEffect](https://reactjs.org/docs/hooks-effect.html) or [componentDidMount](https://reactjs.org/docs/react-component.html#componentdidmount), or Vue's [mounted](https://vuejs.org/v2/api/#mounted).
+<a id="isomorphicuniversal-applications"></a>This library also allows you to use the SDK in [applications that are rendered on the server](https://medium.com/@baphemot/whats-server-side-rendering-and-do-i-need-it-cb42dc059b38). There's really no difference in how you invoke the functions exposed by this library, however you should avoid trying to call them from any code that runs on the server. The easiest way to do this is to call `loadModules()` in component lifecyle hooks that are only invoked in a browser, for example, React's [useEffect](https://reactjs.org/docs/hooks-effect.html) or [componentDidMount](https://reactjs.org/docs/react-component.html#componentdidmount), or Vue's [mounted](https://vuejs.org/v2/api/#mounted).
 
 Alternatively, you could use checks like the following to prevent calling esri-loader functions on the server:
 
@@ -509,7 +509,7 @@ The angular-esri-loader wrapper library is no longer needed and has been depreca
 
 ### Browsers
 
-This library doesn't have any external dependencies, but the functions it exposes to load the ArcGIS API and its modules expect to be run in a browser. This library officially supports [the same browsers that are supported by the latest version of the ArcGIS API for JavaScript](https://developers.arcgis.com/javascript/latest/guide/system-requirements/index.html#supported-browsers). 
+This library doesn't have any external dependencies, but the functions it exposes to load the SDK and its modules expect to be run in a browser. This library officially supports [the same browsers that are supported by the latest version of the ArcGIS Maps SDK for JavaScript](https://developers.arcgis.com/javascript/latest/guide/system-requirements/index.html#supported-browsers). 
 
 You cannot use this helper library in [Node.js](https://nodejs.org/), but you _can_ use this library in [server side rendered applications](#server-side-rendering) as well as [Electron](#electron). If you need to execute requests to ArcGIS REST services from something like a Node.js CLI application, see [ArcGIS Rest JS](https://developers.arcgis.com/arcgis-rest-js/).
 

--- a/archived-examples.md
+++ b/archived-examples.md
@@ -1,6 +1,6 @@
 ### 3.x Types
 
-You can use these instructions in the [Legacy samples for ArcGIS JSAPI Resources](https://github.com/Esri/jsapi-resources/releases/tag/legacy) to install the 3.x types. Follow the instructions outlined in the `/3.x/typescript` directory.
+You can use these instructions in the [Legacy samples for ArcGIS Maps SDK for JavaScript Resources](https://github.com/Esri/jsapi-resources/releases/tag/legacy) to install the 3.x types. Follow the instructions outlined in the `/3.x/typescript` directory.
 
 Use `import * as esri from 'esri';` to implement the types [as shown here](https://github.com/Esri/angular-cli-esri-map/issues/17#issue-360490589).
 
@@ -21,7 +21,7 @@ A more complete 4.x sample can be [seen here](https://codesandbox.io/s/xv8mw2890
 
 ### Legacy browsers
 
-Since this library also works with [v3.x of the ArcGIS API](https://developers.arcgis.com/javascript/3/), the community [has made some effort](https://github.com/Esri/esri-loader/pull/67) to get it to work with [some of the older browsers supported by 3.x](https://developers.arcgis.com/javascript/3/jshelp/supported_browsers.html) like IE < 11.
+Since this library also works with [v3.x of the ArcGIS Maps SDK](https://developers.arcgis.com/javascript/3/), the community [has made some effort](https://github.com/Esri/esri-loader/pull/67) to get it to work with [some of the older browsers supported by 3.x](https://developers.arcgis.com/javascript/3/jshelp/supported_browsers.html) like IE < 11.
 
 ### Legacy examples
 
@@ -31,7 +31,7 @@ Here is an archive of some applications and framework-specific wrapper libraries
 
 #### Reusable libraries for Angular
 
-- [angular-esri-components](https://github.com/TheKeithStewart/angular-esri-components) - A set of Angular components to work with ArcGIS API for JavaScript v4.3
+- [angular-esri-components](https://github.com/TheKeithStewart/angular-esri-components) - A set of Angular components to work with ArcGIS Maps SDK for JavaScript v4.3
 
 #### Example Angular applications
 
@@ -39,7 +39,7 @@ Here is an archive of some applications and framework-specific wrapper libraries
 
 ### [CanJS](https://canjs.com/)
 
-- [can-arcgis](https://github.com/roemhildtg/can-arcgis) - CanJS configurable mapping app (inspired by [cmv-app](https://github.com/cmv/cmv-app)) and components built for the ArcGIS JS API 4.x, bundled with [StealJS](https://stealjs.com/)
+- [can-arcgis](https://github.com/roemhildtg/can-arcgis) - CanJS configurable mapping app (inspired by [cmv-app](https://github.com/cmv/cmv-app)) and components built for the ArcGIS Maps SDK for JavaScript 4.x, bundled with [StealJS](https://stealjs.com/)
 
 ### [Choo](https://choo.io/)
 
@@ -53,7 +53,7 @@ Here is an archive of some applications and framework-specific wrapper libraries
 
 ### [Electron](https://electron.atom.io/)
 
-- [ng-cli-electron-esri](https://github.com/TheKeithStewart/ng-cli-electron-esri) - This project is meant to demonstrate how to run a mapping application using the ArcGIS API for JavaScript inside of Electron
+- [ng-cli-electron-esri](https://github.com/TheKeithStewart/ng-cli-electron-esri) - This project is meant to demonstrate how to run a mapping application using the ArcGIS Maps SDK for JavaScript inside of Electron
 
 #### Reusable libraries for Ember
 
@@ -65,7 +65,7 @@ See the [examples over at ember-esri-loader](https://github.com/Esri/ember-esri-
 
 ### [Glimmer.js](https://glimmerjs.com/)
 
-- [esri-glimmer-example](https://github.com/tomwayson/esri-glimmer-example) - An example of how to use the ArcGIS API for JavaScript in a https://glimmerjs.com/ application
+- [esri-glimmer-example](https://github.com/tomwayson/esri-glimmer-example) - An example of how to use the ArcGIS Maps SDK for JavaScript in a https://glimmerjs.com/ application
 
 ### [Hyperapp](https://hyperapp.js.org/)
 
@@ -73,11 +73,11 @@ See the [examples over at ember-esri-loader](https://github.com/Esri/ember-esri-
 
 ### [Preact](https://github.com/developit/preact)
 
-- [esri-preact-pwa](https://github.com/tomwayson/esri-preact-pwa) - An example progressive web app (PWA) using the ArcGIS API for JavaScript built with Preact
+- [esri-preact-pwa](https://github.com/tomwayson/esri-preact-pwa) - An example progressive web app (PWA) using the ArcGIS Maps SDK for JavaScript built with Preact
 
 #### Reusable libraries for React
 
-- [esri-loader-hooks](https://github.com/tomwayson/esri-loader-hooks) - Custom React hooks for using the ArcGIS API for JavaScript with esri-loader
+- [esri-loader-hooks](https://github.com/tomwayson/esri-loader-hooks) - Custom React hooks for using the ArcGIS Maps SDK for JavaScript with esri-loader
 - [react-arcgis](https://github.com/Esri/react-arcgis) - A few components to help you get started using esri-loader with React
 - [esri-loader-react](https://github.com/davetimmins/esri-loader-react) - A React component wrapper around esri-loader ([blog post](https://davetimmins.github.io/2017/07/19/esri-loader-react/))
 - [arcgis-react-redux-legend](https://github.com/davetimmins/arcgis-react-redux-legend) - Legend control for ArcGIS JS v4 using React and Redux
@@ -86,7 +86,7 @@ See the [examples over at ember-esri-loader](https://github.com/Esri/ember-esri-
 - [create-arcgis-app](https://github.com/tomwayson/create-arcgis-app/) - An example of how to use the ArcGIS platform in an application created with Create React App and React Router.
 - [next-arcgis-app](https://github.com/tomwayson/next-arcgis-app/) - An example of how to use the ArcGIS platform in an application built with Next.js
 - [esri-loader-react-starter-kit](https://github.com/tomwayson/esri-loader-react-starter-kit) - A fork of the [react-starter-kit](https://github.com/kriasoft/react-starter-kit) showing how to use esri-loader in an isomorphic/universal React application
-- [create-react-app-esri-loader](https://github.com/davetimmins/create-react-app-esri-loader/) - An example create-react-app application that uses [esri-loader-react](https://github.com/davetimmins/esri-loader-react) to load the ArcGIS API
+- [create-react-app-esri-loader](https://github.com/davetimmins/create-react-app-esri-loader/) - An example create-react-app application that uses [esri-loader-react](https://github.com/davetimmins/esri-loader-react) to load the ArcGIS Maps SDK for JavaScript
 - [React-Typescript-App-with-ArcGIS-JSAPI](https://github.com/guzhongren/React-Typescript-App-with-ArcGIS-JSAPI) - An example create-react-app application that uses [esri-loader](https://github.com/Esri/esri-loader), [esri-loader-react](https://github.com/davetimmins/esri-loader-react), [Typescript](https://www.typescriptlang.org/), [Webpack3](https://webpack.js.org/) to create MapView
 
 ### [Riot](https://riot.js.org/)
@@ -105,6 +105,6 @@ See the [examples over at ember-esri-loader](https://github.com/Esri/ember-esri-
 ### [Vue.js](https://vuejs.org/)
 
 - [CreateMap](https://github.com/oppoudel/CreateMap) - Create Map: City of Baltimore - https://gis.baltimorecity.gov/createmap/#/
-- [City of Baltimore: Map Gallery](https://github.com/oppoudel/MapGallery_Vue) - Map Gallery built with Vue.js that uses this library to load the ArcGIS API
-- [vue-jsapi4](https://github.com/odoe/vue-jsapi4) - An example of how to use the [ArcGIS API for Javascript](https://developers.arcgis.com/javascript/) in a [NUXT](https://nuxtjs.org/) application ([blog post](https://odoe.net/blog/arcgis-api-4-for-js-with-vue-cli-and-nuxt/), [video](https://youtu.be/hqJzzgM8seo))
-- [esri-vue-cli-example](https://github.com/tomwayson/esri-vue-cli-example) - An example of how to use the [ArcGIS API for JavaScript 3.x](https://developers.arcgis.com/javascript/3/) in a [vue-cli](https://github.com/vuejs/vue-cli) application
+- [City of Baltimore: Map Gallery](https://github.com/oppoudel/MapGallery_Vue) - Map Gallery built with Vue.js that uses this library to load the ArcGIS SDK
+- [vue-jsapi4](https://github.com/odoe/vue-jsapi4) - An example of how to use the [ArcGIS Maps SDK for Javascript](https://developers.arcgis.com/javascript/) in a [NUXT](https://nuxtjs.org/) application ([blog post](https://odoe.net/blog/arcgis-api-4-for-js-with-vue-cli-and-nuxt/), [video](https://youtu.be/hqJzzgM8seo))
+- [esri-vue-cli-example](https://github.com/tomwayson/esri-vue-cli-example) - An example of how to use the [ArcGIS Maps SDK for JavaScript 3.x](https://developers.arcgis.com/javascript/3/) in a [vue-cli](https://github.com/vuejs/vue-cli) application

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "esri-loader",
   "version": "3.7.0",
-  "description": "A tiny library to help load ArcGIS API for JavaScript modules in non-Dojo applications",
+  "description": "A tiny library to help load ArcGIS Maps SDK for JavaScript modules in non-Dojo applications",
   "files": [
     "dist"
   ],

--- a/src/modules.ts
+++ b/src/modules.ts
@@ -19,7 +19,7 @@ function requireModules<T extends any[] = any[]>(modules: string[]): Promise<T> 
 }
 
 // returns a promise that resolves with an array of the required modules
-// also will attempt to lazy load the ArcGIS Maps SDK for JavaScript 
+// also will attempt to lazy load the API
 // if it has not already been loaded
 export function loadModules<T extends any[] = any[]>(modules: string[], loadScriptOptions: ILoadScriptOptions = {}): Promise<T> {
   if (!isLoaded()) {

--- a/src/modules.ts
+++ b/src/modules.ts
@@ -19,7 +19,8 @@ function requireModules<T extends any[] = any[]>(modules: string[]): Promise<T> 
 }
 
 // returns a promise that resolves with an array of the required modules
-// also will attempt to lazy load the ArcGIS API if it has not already been loaded
+// also will attempt to lazy load the ArcGIS Maps SDK for JavaScript 
+// if it has not already been loaded
 export function loadModules<T extends any[] = any[]>(modules: string[], loadScriptOptions: ILoadScriptOptions = {}): Promise<T> {
   if (!isLoaded()) {
     // script is not yet loaded, is it in the process of loading?

--- a/src/script.test.ts
+++ b/src/script.test.ts
@@ -12,7 +12,7 @@ declare global {
   /* tslint:enable interface-name */
 }
 
-// allow the mock scripts to emulate that the JSAPI has loaded
+// allow the mock scripts to emulate that the SDK has loaded
 window.stubRequire = stubRequire;
 
 // remove script tags added by esri-loader
@@ -190,7 +190,7 @@ describe('when loading the script', function() {
         done.fail('call to loadScript should have failed');
       })
       .catch((err) => {
-        expect(err.message).toEqual(`The ArcGIS API for JavaScript is already loaded.`);
+        expect(err.message).toEqual(`The ArcGIS Maps SDK for JavaScript is already loaded.`);
         done();
       });
     });
@@ -276,7 +276,7 @@ describe('when loading the script', function() {
           done.fail('second call to loadScript should have failed');
         })
         .catch((err) => {
-          expect(err.message).toEqual(`The ArcGIS API for JavaScript is already loaded (${jaspi3xUrl}).`);
+          expect(err.message).toEqual(`The ArcGIS Maps SDK for JavaScript is already loaded (${jaspi3xUrl}).`);
           done();
         });
       });

--- a/src/script.test.ts
+++ b/src/script.test.ts
@@ -190,7 +190,7 @@ describe('when loading the script', function() {
         done.fail('call to loadScript should have failed');
       })
       .catch((err) => {
-        expect(err.message).toEqual(`The ArcGIS API is already loaded.`);
+        expect(err.message).toEqual(`The ArcGIS API for JavaScript is already loaded.`);
         done();
       });
     });
@@ -276,7 +276,7 @@ describe('when loading the script', function() {
           done.fail('second call to loadScript should have failed');
         })
         .catch((err) => {
-          expect(err.message).toEqual(`The ArcGIS API is already loaded (${jaspi3xUrl}).`);
+          expect(err.message).toEqual(`The ArcGIS API for JavaScript is already loaded (${jaspi3xUrl}).`);
           done();
         });
       });

--- a/src/script.test.ts
+++ b/src/script.test.ts
@@ -12,7 +12,7 @@ declare global {
   /* tslint:enable interface-name */
 }
 
-// allow the mock scripts to emulate that the API has loaded
+// allow the mock scripts to emulate that the SDK has loaded
 window.stubRequire = stubRequire;
 
 // remove script tags added by esri-loader

--- a/src/script.test.ts
+++ b/src/script.test.ts
@@ -12,7 +12,7 @@ declare global {
   /* tslint:enable interface-name */
 }
 
-// allow the mock scripts to emulate that the SDK has loaded
+// allow the mock scripts to emulate that the API has loaded
 window.stubRequire = stubRequire;
 
 // remove script tags added by esri-loader
@@ -190,7 +190,7 @@ describe('when loading the script', function() {
         done.fail('call to loadScript should have failed');
       })
       .catch((err) => {
-        expect(err.message).toEqual(`The ArcGIS Maps SDK for JavaScript is already loaded.`);
+        expect(err.message).toEqual(`The ArcGIS API is already loaded.`);
         done();
       });
     });
@@ -276,7 +276,7 @@ describe('when loading the script', function() {
           done.fail('second call to loadScript should have failed');
         })
         .catch((err) => {
-          expect(err.message).toEqual(`The ArcGIS Maps SDK for JavaScript is already loaded (${jaspi3xUrl}).`);
+          expect(err.message).toEqual(`The ArcGIS API is already loaded (${jaspi3xUrl}).`);
           done();
         });
       });

--- a/src/script.ts
+++ b/src/script.ts
@@ -100,7 +100,7 @@ export function loadScript(options: ILoadScriptOptions = {}): Promise<HTMLScript
       const src = script.getAttribute('src');
       if (src !== url) {
         // potentially trying to load a different version of the API
-        reject(new Error(`The ArcGIS API is already loaded (${src}).`));
+        reject(new Error(`The ArcGIS API for JavaScript is already loaded (${src}).`));
       } else {
         if (isLoaded()) {
           // the script has already successfully loaded
@@ -114,7 +114,7 @@ export function loadScript(options: ILoadScriptOptions = {}): Promise<HTMLScript
       if (isLoaded()) {
         // the API has been loaded by some other means
         // potentially trying to load a different version of the API
-        reject(new Error(`The ArcGIS API is already loaded.`));
+        reject(new Error(`The ArcGIS API for JavaScript is already loaded.`));
       } else {
         // this is the first time attempting to load the API
         const css = opts.css;

--- a/src/script.ts
+++ b/src/script.ts
@@ -67,14 +67,14 @@ export function setDefaultOptions(options: ILoadScriptOptions = {}): void {
 export function getScript() {
   return document.querySelector('script[data-esri-loader]') as HTMLScriptElement;
 }
-// has ArcGIS SDK been loaded on the page yet?
+// has ArcGIS API been loaded on the page yet?
 export function isLoaded() {
   const globalRequire = window['require'];
   // .on() ensures that it's Dojo's AMD loader
   return globalRequire && globalRequire.on;
 }
 
-// load the ArcGIS SDK on the page
+// load the ArcGIS API on the page
 export function loadScript(options: ILoadScriptOptions = {}): Promise<HTMLScriptElement> {
   // we would have liked to use spread like { ...defaultOptions, ...options }
   // but TS would inject a polyfill that would require use to configure rollup w content: 'window'
@@ -94,13 +94,13 @@ export function loadScript(options: ILoadScriptOptions = {}): Promise<HTMLScript
   return new utils.Promise((resolve, reject) => {
     let script = getScript();
     if (script) {
-      // the SDK is already loaded or in the process of loading...
+      // the API is already loaded or in the process of loading...
       // NOTE: have to test against scr attribute value, not script.src
       // b/c the latter will return the full url for relative paths
       const src = script.getAttribute('src');
       if (src !== url) {
-        // potentially trying to load a different version of the SDK
-        reject(new Error(`The ArcGIS Maps SDK for JavaScript is already loaded (${src}).`));
+        // potentially trying to load a different version of the API
+        reject(new Error(`The ArcGIS API is already loaded (${src}).`));
       } else {
         if (isLoaded()) {
           // the script has already successfully loaded
@@ -112,18 +112,18 @@ export function loadScript(options: ILoadScriptOptions = {}): Promise<HTMLScript
       }
     } else {
       if (isLoaded()) {
-        // the SDK has been loaded by some other means
-        // potentially trying to load a different version of the SDK
-        reject(new Error(`The ArcGIS Maps SDK for JavaScript is already loaded.`));
+        // the API has been loaded by some other means
+        // potentially trying to load a different version of the API
+        reject(new Error(`The ArcGIS API is already loaded.`));
       } else {
-        // this is the first time attempting to load the SDK
+        // this is the first time attempting to load the API
         const css = opts.css;
         if (css) {
           const useVersion = css === true;
           // load the css before loading the script
           loadCss(useVersion ? version : (css as string), opts.insertCssBefore);
         }
-        // create a script object whose source points to the SDK
+        // create a script object whose source points to the API
         script = createScript(url);
         // _currentUrl = url;
         // once the script is loaded...

--- a/src/script.ts
+++ b/src/script.ts
@@ -67,14 +67,14 @@ export function setDefaultOptions(options: ILoadScriptOptions = {}): void {
 export function getScript() {
   return document.querySelector('script[data-esri-loader]') as HTMLScriptElement;
 }
-// has ArcGIS API been loaded on the page yet?
+// has ArcGIS SDK been loaded on the page yet?
 export function isLoaded() {
   const globalRequire = window['require'];
   // .on() ensures that it's Dojo's AMD loader
   return globalRequire && globalRequire.on;
 }
 
-// load the ArcGIS API on the page
+// load the ArcGIS SDK on the page
 export function loadScript(options: ILoadScriptOptions = {}): Promise<HTMLScriptElement> {
   // we would have liked to use spread like { ...defaultOptions, ...options }
   // but TS would inject a polyfill that would require use to configure rollup w content: 'window'
@@ -94,13 +94,13 @@ export function loadScript(options: ILoadScriptOptions = {}): Promise<HTMLScript
   return new utils.Promise((resolve, reject) => {
     let script = getScript();
     if (script) {
-      // the API is already loaded or in the process of loading...
+      // the SDK is already loaded or in the process of loading...
       // NOTE: have to test against scr attribute value, not script.src
       // b/c the latter will return the full url for relative paths
       const src = script.getAttribute('src');
       if (src !== url) {
-        // potentially trying to load a different version of the API
-        reject(new Error(`The ArcGIS API for JavaScript is already loaded (${src}).`));
+        // potentially trying to load a different version of the SDK
+        reject(new Error(`The ArcGIS Maps SDK for JavaScript is already loaded (${src}).`));
       } else {
         if (isLoaded()) {
           // the script has already successfully loaded
@@ -112,18 +112,18 @@ export function loadScript(options: ILoadScriptOptions = {}): Promise<HTMLScript
       }
     } else {
       if (isLoaded()) {
-        // the API has been loaded by some other means
-        // potentially trying to load a different version of the API
-        reject(new Error(`The ArcGIS API for JavaScript is already loaded.`));
+        // the SDK has been loaded by some other means
+        // potentially trying to load a different version of the SDK
+        reject(new Error(`The ArcGIS Maps SDK for JavaScript is already loaded.`));
       } else {
-        // this is the first time attempting to load the API
+        // this is the first time attempting to load the SDK
         const css = opts.css;
         if (css) {
           const useVersion = css === true;
           // load the css before loading the script
           loadCss(useVersion ? version : (css as string), opts.insertCssBefore);
         }
-        // create a script object whose source points to the API
+        // create a script object whose source points to the SDK
         script = createScript(url);
         // _currentUrl = url;
         // once the script is loaded...

--- a/src/utils/css.ts
+++ b/src/utils/css.ts
@@ -34,7 +34,7 @@ function getCssUrl(urlOrVersion?: string) {
     : urlOrVersion;
 }
 
-// lazy load the CSS needed for the ArcGIS API
+// lazy load the CSS needed for the ArcGIS Maps SDK for JavaScript
 export function loadCss(urlOrVersion?: string, before?: string) {
   const url = getCssUrl(urlOrVersion);
   let link = getCss(url);


### PR DESCRIPTION
This PR replaces all instances of the old naming convention with the new name. It roughly follows a convention of using the full name once per section followed by just using shorthand "SDK" or "API" where appropriate. The plan is to merge this PR next week, on/around Dec 14.

For more information see the [Introducing the ArcGIS Map SDKs](https://www.esri.com/arcgis-blog/products/developers/announcements/introducing-the-arcgis-maps-sdks/) blog post. 

Items of note:
* This PR does not create a new version of the esri-loader library.